### PR TITLE
lazy spinner directive

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade7-landing.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade7-landing.controller.js
@@ -18,6 +18,7 @@
         vm.beginUpgrade = beginUpgrade;
 
         vm.prechecks = {
+            running: false,
             completed: false,
             valid: false,
             checks: {
@@ -45,6 +46,7 @@
          * Pre validation checks
          */
         function runPrechecks() {
+            vm.prechecks.running = true;
             upgradePrechecksFactory
                 .getAll()
                 .then(
@@ -74,6 +76,7 @@
                     function() {
                         // Either on sucess or failure, the prechecks has been completed.
                         vm.prechecks.completed = true;
+                        vm.prechecks.running = false;
                     }
                 );
 

--- a/assets/app/features/upgrade/controllers/upgrade7-landing.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade7-landing.controller.js
@@ -21,6 +21,7 @@
             running: false,
             completed: false,
             valid: false,
+            spinnerVisible: false,
             checks: {
                 updates_installed: false,
                 network_sanity: false,

--- a/assets/app/features/upgrade/templates/upgrade7/landing.jade
+++ b/assets/app/features/upgrade/templates/upgrade7/landing.jade
@@ -30,7 +30,7 @@
         ng-disabled="Upgrade7LandingVm.prechecks.completed && Upgrade7LandingVm.prechecks.valid",
         ng-click="Upgrade7LandingVm.prechecks.runPrechecks()"
       )
-          suse-lazy-spinner(active="Upgrade7LandingVm.prechecks.running")
+          suse-lazy-spinner(delay="2000", active="Upgrade7LandingVm.prechecks.running")
           span(translate='') upgrade7.steps.landing.prechecks.form.check-again
     
     p.note-message(translate='') upgrade7.steps.landing.note

--- a/assets/app/features/upgrade/templates/upgrade7/landing.jade
+++ b/assets/app/features/upgrade/templates/upgrade7/landing.jade
@@ -31,7 +31,7 @@
         ng-class="{active: Upgrade7LandingVm.prechecks.spinnerVisible}",
         ng-click="Upgrade7LandingVm.prechecks.runPrechecks()"
       )
-          suse-lazy-spinner(delay="2000", active="Upgrade7LandingVm.prechecks.running",\
+          suse-lazy-spinner(delay="2000", active="Upgrade7LandingVm.prechecks.running",
             visible="Upgrade7LandingVm.prechecks.spinnerVisible")
           span(translate='') upgrade7.steps.landing.prechecks.form.check-again
     

--- a/assets/app/features/upgrade/templates/upgrade7/landing.jade
+++ b/assets/app/features/upgrade/templates/upgrade7/landing.jade
@@ -28,10 +28,11 @@
   
       button.btn.btn-default.btn-sm(
         ng-disabled="Upgrade7LandingVm.prechecks.completed && Upgrade7LandingVm.prechecks.valid",
-        ng-class="{active: Upgrade7LandingVm.prechecks.running}",
+        ng-class="{active: Upgrade7LandingVm.prechecks.spinnerVisible}",
         ng-click="Upgrade7LandingVm.prechecks.runPrechecks()"
       )
-          suse-lazy-spinner(delay="2000", active="Upgrade7LandingVm.prechecks.running")
+          suse-lazy-spinner(delay="2000", active="Upgrade7LandingVm.prechecks.running",\
+            visible="Upgrade7LandingVm.prechecks.spinnerVisible")
           span(translate='') upgrade7.steps.landing.prechecks.form.check-again
     
     p.note-message(translate='') upgrade7.steps.landing.note

--- a/assets/app/features/upgrade/templates/upgrade7/landing.jade
+++ b/assets/app/features/upgrade/templates/upgrade7/landing.jade
@@ -26,10 +26,12 @@
           }")
           span(translate='upgrade7.steps.landing.prechecks.codes.{{::checkKey}}') 
   
-      button.btn.btn-default.btn-sm(translate='', 
+      button.btn.btn-default.btn-sm(
         ng-disabled="Upgrade7LandingVm.prechecks.completed && Upgrade7LandingVm.prechecks.valid",
         ng-click="Upgrade7LandingVm.prechecks.runPrechecks()"
-      ) upgrade7.steps.landing.prechecks.form.check-again
+      )
+          suse-lazy-spinner(active="Upgrade7LandingVm.prechecks.running")
+          span(translate='') upgrade7.steps.landing.prechecks.form.check-again
     
     p.note-message(translate='') upgrade7.steps.landing.note
 

--- a/assets/app/features/upgrade/templates/upgrade7/landing.jade
+++ b/assets/app/features/upgrade/templates/upgrade7/landing.jade
@@ -28,6 +28,7 @@
   
       button.btn.btn-default.btn-sm(
         ng-disabled="Upgrade7LandingVm.prechecks.completed && Upgrade7LandingVm.prechecks.valid",
+        ng-class="{active: Upgrade7LandingVm.prechecks.running}",
         ng-click="Upgrade7LandingVm.prechecks.runPrechecks()"
       )
           suse-lazy-spinner(delay="2000", active="Upgrade7LandingVm.prechecks.running")

--- a/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.jade
+++ b/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.jade
@@ -1,0 +1,1 @@
+i.fa.fa-fw.fa-spin.fa-spinner(aria-hidden="true")

--- a/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.js
+++ b/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.js
@@ -1,0 +1,50 @@
+(function() {
+    'use strict';
+
+    angular
+        .module('crowbarWidgets')
+        .directive('suseLazySpinner', lazySpinner);
+
+    lazySpinner.$inject = ['$timeout'];
+
+    function lazySpinner($timeout) {
+        return {
+            restrict: 'E',
+            templateUrl: 'app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.html',
+            scope: {
+                active: '=',
+                delay: '@'
+            },
+            link: function(scope, elem) {
+                hideSpinner();
+
+                scope.$watch('active', function(newVal){
+                    newVal ? showSpinner() : hideSpinner();
+                });
+
+                var timer = null;
+
+                function showSpinner() {
+                    if (timer)
+                        return;
+                    timer = $timeout(function() { elem.css({display: ''}); }, getDelay());
+                }
+
+                function hideSpinner() {
+                    // cancel (possibly) pending timer
+                    if (timer) {
+                        $timeout.cancel(timer);
+                        timer = null;
+                    }
+
+                    elem.css({display: 'none'});
+                }
+
+                function getDelay() {
+                    var delay = parseInt(scope.delay);
+                    return isFinite(delay) ? delay : 2000;
+                }
+            }
+        };
+    }
+})();

--- a/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.js
+++ b/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.js
@@ -13,26 +13,28 @@
             templateUrl: 'app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.html',
             scope: {
                 active: '=',
+                visible: '=?',
                 delay: '@'
             },
             link: function(scope, elem) {
-                hideSpinner();
+                // dummy-init optional binding values
+                scope.visible = scope.visible || false;
 
                 scope.$watch('active', function(newVal) {
                     newVal ? showSpinner() : hideSpinner();
                 });
 
-                elem.on('$destroy', function() {
-                    if (timer)
-                        $timeout.cancel(timer);
-                });
+                elem.on('$destroy', hideSpinner);
 
                 var timer = null;
 
                 function showSpinner() {
                     if (timer)
                         return;
-                    timer = $timeout(function() { elem.css({display: ''}); }, getDelay());
+                    timer = $timeout(function() {
+                        elem.addClass('visible');
+                        scope.visible = true;
+                    }, getDelay());
                 }
 
                 function hideSpinner() {
@@ -42,7 +44,8 @@
                         timer = null;
                     }
 
-                    elem.css({display: 'none'});
+                    elem.removeClass('visible');
+                    scope.visible = false;
                 }
 
                 function getDelay() {

--- a/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.js
+++ b/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.js
@@ -18,8 +18,13 @@
             link: function(scope, elem) {
                 hideSpinner();
 
-                scope.$watch('active', function(newVal){
+                scope.$watch('active', function(newVal) {
                     newVal ? showSpinner() : hideSpinner();
+                });
+
+                elem.on('$destroy', function() {
+                    if (timer)
+                        $timeout.cancel(timer);
                 });
 
                 var timer = null;

--- a/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.js
+++ b/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.js
@@ -3,11 +3,12 @@
 
     angular
         .module('crowbarWidgets')
-        .directive('suseLazySpinner', lazySpinner);
+        .directive('suseLazySpinner', suseLazySpinner)
+        .constant('SUSE_LAZY_SPINNER', { DEFAULT_DELAY: 2000 });
 
-    lazySpinner.$inject = ['$timeout'];
+    suseLazySpinner.$inject = ['$timeout', 'SUSE_LAZY_SPINNER'];
 
-    function lazySpinner($timeout) {
+    function suseLazySpinner($timeout, SUSE_LAZY_SPINNER) {
         return {
             restrict: 'E',
             templateUrl: 'app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.html',
@@ -29,10 +30,11 @@
                 var timer = null;
 
                 function showSpinner() {
-                    if (timer)
+                    if (timer) {
                         return;
+                    }
                     timer = $timeout(function() {
-                        elem.addClass('visible');
+                        elem.removeClass('hidden');
                         scope.visible = true;
                     }, getDelay());
                 }
@@ -44,13 +46,13 @@
                         timer = null;
                     }
 
-                    elem.removeClass('visible');
+                    elem.addClass('hidden');
                     scope.visible = false;
                 }
 
                 function getDelay() {
                     var delay = parseInt(scope.delay);
-                    return isFinite(delay) ? delay : 2000;
+                    return isFinite(delay) ? delay : SUSE_LAZY_SPINNER.DEFAULT_DELAY;
                 }
             }
         };

--- a/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.spec.js
+++ b/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.spec.js
@@ -1,7 +1,7 @@
 /*global bard $httpBackend assert $rootScope $compile $timeout */
 describe('SUSE Lazy Spinner Directive', function () {
 
-    var directiveElem,
+    var directiveElement,
         scope;
 
     beforeEach(function () {
@@ -16,12 +16,12 @@ describe('SUSE Lazy Spinner Directive', function () {
         scope = $rootScope.$new();
     });
 
-    function compileDirective(tpl) {
-        var elem = angular.element(tpl);
-        var compiledElem = $compile(elem)(scope);
+    function compileDirective(template) {
+        var element = angular.element(template),
+            compiledElement = $compile(element)(scope);
         scope.$digest();
 
-        return compiledElem;
+        return compiledElement;
     }
 
     // Verify no unexpected http call has been made
@@ -29,11 +29,11 @@ describe('SUSE Lazy Spinner Directive', function () {
 
     describe('directive created with default parameters', function () {
         beforeEach(function () {
-            directiveElem = compileDirective('<suse-lazy-spinner active="testActive">');
+            directiveElement = compileDirective('<suse-lazy-spinner active="testActive"></suse-lazy-spinner>');
         });
 
         it('should contain an icon with fa-spin class', function () {
-            var icons = directiveElem.find('i');
+            var icons = directiveElement.find('i');
             expect(icons.length).toEqual(1);
             assert.isTrue(angular.element(icons[0]).hasClass('fa-spin'));
         });
@@ -47,11 +47,11 @@ describe('SUSE Lazy Spinner Directive', function () {
             });
 
             it('should be inactive', function () {
-                assert.isFalse(directiveElem.isolateScope().active);
+                assert.isFalse(directiveElement.isolateScope().active);
             });
 
             it('should be hidden', function () {
-                assert.isTrue(directiveElem.hasClass('hidden'));
+                assert.isTrue(directiveElement.hasClass('hidden'));
             });
         });
 
@@ -62,16 +62,16 @@ describe('SUSE Lazy Spinner Directive', function () {
             });
 
             it('should be active', function () {
-                assert.isTrue(directiveElem.isolateScope().active);
+                assert.isTrue(directiveElement.isolateScope().active);
             });
 
             it('should be hidden before the timeout', function () {
-                assert.isTrue(directiveElem.hasClass('hidden'));
+                assert.isTrue(directiveElement.hasClass('hidden'));
             });
 
             it('should not be hidden after the timeout', function () {
                 $timeout.flush();
-                assert.isFalse(directiveElem.hasClass('hidden'));
+                assert.isFalse(directiveElement.hasClass('hidden'));
             });
         });
     });
@@ -79,18 +79,22 @@ describe('SUSE Lazy Spinner Directive', function () {
     describe('directive with custom delay', function () {
         beforeEach(function () {
             scope.testActive = true;
-            directiveElem = compileDirective('<suse-lazy-spinner active="testActive" delay="100">');
+            directiveElement = compileDirective(
+                '<suse-lazy-spinner active="testActive" delay="100"></suse-lazy-spinner>'
+            );
         });
 
         it('should have the delay value in the internal scope', function () {
             // NOTE: the value is parsed internally in the directive which is not visible from the outside
-            expect(directiveElem.isolateScope().delay).toEqual('100');
+            expect(directiveElement.isolateScope().delay).toEqual('100');
         });
     });
 
     describe('directive with exposed visiblity', function () {
         beforeEach(function () {
-            directiveElem = compileDirective('<suse-lazy-spinner active="testActive" visible="spinnerVisible">');
+            directiveElement = compileDirective(
+                '<suse-lazy-spinner active="testActive" visible="spinnerVisible"></suse-lazy-spinner>'
+            );
         });
 
         describe('attached to active model', function () {

--- a/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.spec.js
+++ b/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.spec.js
@@ -1,0 +1,125 @@
+/*global bard $httpBackend assert $rootScope $compile $timeout */
+describe('SUSE Lazy Spinner Directive', function () {
+
+    var directiveElem,
+        scope;
+
+    beforeEach(function () {
+        bard.appModule('crowbarApp');
+
+        bard.inject('$rootScope', '$compile', '$httpBackend', '$timeout');
+
+        //Mock requests that are expected to be made
+        $httpBackend.expectGET('app/features/upgrade/i18n/en.json').respond({});
+        $httpBackend.flush();
+
+        scope = $rootScope.$new();
+    });
+
+    function compileDirective(tpl) {
+        var elem = angular.element(tpl);
+        var compiledElem = $compile(elem)(scope);
+        scope.$digest();
+
+        return compiledElem;
+    }
+
+    // Verify no unexpected http call has been made
+    bard.verifyNoOutstandingHttpRequests();
+
+    describe('directive created with default parameters', function () {
+        beforeEach(function () {
+            directiveElem = compileDirective('<suse-lazy-spinner active="testActive">');
+        });
+
+        it('should contain an icon with fa-spin class', function () {
+            var icons = directiveElem.find('i');
+            expect(icons.length).toEqual(1);
+            assert.isTrue(angular.element(icons[0]).hasClass('fa-spin'));
+        });
+
+        describe('attached to inactive model', function () {
+            beforeEach(function () {
+                scope.testActive = false;
+                scope.$digest();
+                // make sure nothing is scheduled
+                $timeout.flush();
+            });
+
+            it('should be inactive', function () {
+                assert.isFalse(directiveElem.isolateScope().active);
+            });
+
+            it('should be hidden', function () {
+                assert.isTrue(directiveElem.hasClass('hidden'));
+            });
+        });
+
+        describe('attached to active model', function () {
+            beforeEach(function () {
+                scope.testActive = true;
+                scope.$digest();
+            });
+
+            it('should be active', function () {
+                assert.isTrue(directiveElem.isolateScope().active);
+            });
+
+            it('should be hidden before the timeout', function () {
+                assert.isTrue(directiveElem.hasClass('hidden'));
+            });
+
+            it('should not be hidden after the timeout', function () {
+                $timeout.flush();
+                assert.isFalse(directiveElem.hasClass('hidden'));
+            });
+        });
+    });
+
+    describe('directive with custom delay', function () {
+        beforeEach(function () {
+            scope.testActive = true;
+            directiveElem = compileDirective('<suse-lazy-spinner active="testActive" delay="100">');
+        });
+
+        it('should have the delay value in the internal scope', function () {
+            // NOTE: the value is parsed internally in the directive which is not visible from the outside
+            expect(directiveElem.isolateScope().delay).toEqual('100');
+        });
+    });
+
+    describe('directive with exposed visiblity', function () {
+        beforeEach(function () {
+            directiveElem = compileDirective('<suse-lazy-spinner active="testActive" visible="spinnerVisible">');
+        });
+
+        describe('attached to active model', function () {
+            beforeEach(function () {
+                scope.testActive = true;
+                scope.$digest();
+            });
+
+            it('should set visibility to false before timeout', function () {
+                assert.isFalse(scope.spinnerVisible);
+            });
+
+            it('should set visibility to true after timeout', function () {
+                $timeout.flush();
+                assert.isTrue(scope.spinnerVisible);
+            });
+        });
+
+        describe('attached to inactive model', function () {
+            beforeEach(function () {
+                scope.testActive = false;
+                scope.$digest();
+                // make sure nothing is scheduled
+                $timeout.flush();
+            });
+
+            it('should set visibility to false', function () {
+                assert.isFalse(scope.spinnerVisible);
+            });
+        });
+    });
+});

--- a/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.less
+++ b/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.less
@@ -1,8 +1,5 @@
 /* Start= widgets/suse-lazy-spinner/suse-lazy-spinner.less */
 suse-lazy-spinner {
-    display: none;
-}
-suse-lazy-spinner.visible {
     display: inline-block;
 }
 /* End= widgets/suse-lazy-spinner/suse-lazy-spinner.less */

--- a/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.less
+++ b/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.less
@@ -3,6 +3,6 @@ suse-lazy-spinner {
     display: none;
 }
 suse-lazy-spinner.visible {
-    display: inherit;
+    display: inline-block;
 }
 /* End= widgets/suse-lazy-spinner/suse-lazy-spinner.less */

--- a/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.less
+++ b/assets/app/widgets/suse-lazy-spinner/suse-lazy-spinner.less
@@ -1,0 +1,8 @@
+/* Start= widgets/suse-lazy-spinner/suse-lazy-spinner.less */
+suse-lazy-spinner {
+    display: none;
+}
+suse-lazy-spinner.visible {
+    display: inherit;
+}
+/* End= widgets/suse-lazy-spinner/suse-lazy-spinner.less */

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,7 +19,8 @@ module.exports = function(config) {
             'bower_components/bardjs/dist/bard.js',
             'bower_components/bardjs/dist/bard-ngRouteTester.js',
             'assets/app/**/*.module.js',
-            'assets/app/**/*.js'
+            'assets/app/**/*.js',
+            'public/app/crowbar-app.templates.js'
         ],
 
 

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -46,6 +46,7 @@ html(ng-app='crowbarApp')
     script(src='app/widgets/crowbar-upgrade-steps/crowbar-upgrade-steps.directive.js')
     script(src='app/widgets/crowbar-upgrade-nav/crowbar-upgrade-nav.directive.js')
     script(src='app/widgets/crowbar-header/crowbar-header.directive.js')
+    script(src='app/widgets/suse-lazy-spinner/suse-lazy-spinner.directive.js')
 
     // Crowbar Features
     // Upgrade State


### PR DESCRIPTION
This directive adds a spinner which can be activated by a boolean value but will show only when active for more than specified `delay`.

To use just insert: `<suse-lazy-spinner delay="3000" active="vm.running">` into your button or any other element where the spinner is required.
Default delay (if not specified) is `2000` (2s).

If you need feedback when the spinner is actually visible, bind a scope variable to `visible` attribute.
E.g. `<suse-lazy-spinner active="vm.running" visible="vm.spinnerVisible">`.
This can be used to simplify the styling as you can change styles on the parent elements in sync with the spinner events.

In this PR there is an example of using this directive on the landing page. Note that the test backend needs to be slowed down in order to see the effect of this directive.
