### PR TITLE
Integrated Admin Server Backup page with backend.

### DIFF
--- a/assets/app/data/services/upgrade/backup.factory.js
+++ b/assets/app/data/services/upgrade/backup.factory.js
@@ -4,22 +4,39 @@
         .module('crowbarData.upgrade')
         .factory('upgradeBackupFactory', upgradeBackupFactory);
 
-    upgradeBackupFactory.$inject = ['$q', '$http', 'COMMON_API_V2_HEADERS'];
+    upgradeBackupFactory.$inject = ['$q', '$http', '$filter', 'COMMON_API_V2_HEADERS'];
     /* @ngInject */
-    function upgradeBackupFactory($q, $http, COMMON_API_V2_HEADERS) {
+    function upgradeBackupFactory($q, $http, $filter, COMMON_API_V2_HEADERS) {
         var factory = {
-            create: getBackup
+            create: createBackup,
+            download: downloadBackup
         };
 
         return factory;
 
-        function getBackup() {
+        function createBackup() {
 
             var requestOptions = {
                 method: 'POST',
+                url: '/api/crowbar/backups',
+                data: { name: 'upgrade-backup-' + $filter('date')(new Date, 'yyyyMMddHHmmss') },
+                headers: COMMON_API_V2_HEADERS
+            };
+
+            return $http(requestOptions);
+        }
+
+        function downloadBackup(id) {
+            // this should never happen, caller should make sure 'id' is set
+            if (angular.isUndefined(id)) {
+                throw Error('downloadBackup() called without id.');
+            }
+
+            var requestOptions = {
+                method: 'GET',
                 cache: false,
                 responseType: 'arraybuffer',
-                url: '/api/upgrade7/backup',
+                url: '/api/crowbar/backups/' + id + '/download',
                 headers: COMMON_API_V2_HEADERS
             };
 

--- a/assets/app/data/services/upgrade/backup.factory.spec.js
+++ b/assets/app/data/services/upgrade/backup.factory.spec.js
@@ -2,7 +2,10 @@
 describe('Upgrade Backup Factory', function () {
 
     var mockedBackupFile = '--mockedBackupFile--',
-        prechecksPromise;
+        mockedCreateResponse = {
+            id: 42
+        },
+        backupPromise;
 
     beforeEach(function () {
         //Setup the module and dependencies to be used.
@@ -22,41 +25,78 @@ describe('Upgrade Backup Factory', function () {
             should.exist(upgradeBackupFactory);
         });
 
-        it('returns an object with create function is defined', function () {
+        it('returns an object with create function defined', function () {
             expect(upgradeBackupFactory.create).toEqual(jasmine.any(Function));
+        });
+
+        it('returns an object with download function defined', function () {
+            expect(upgradeBackupFactory.download).toEqual(jasmine.any(Function));
         });
 
         describe('when create method is executed', function () {
 
             beforeEach(function () {
-
-                $httpBackend.expect('POST', '/api/upgrade7/backup')
-                    .respond(200, mockedBackupFile);
-                prechecksPromise = upgradeBackupFactory.create();
+                $httpBackend.expect('POST', '/api/crowbar/backups')
+                    .respond(200, mockedCreateResponse);
+                backupPromise = upgradeBackupFactory.create();
                 $httpBackend.flush();
             });
 
             it('returns a promise', function () {
-                expect(prechecksPromise).toEqual(jasmine.any(Object));
-                expect(prechecksPromise['then']).toEqual(jasmine.any(Function));
-                expect(prechecksPromise['catch']).toEqual(jasmine.any(Function));
-                expect(prechecksPromise['finally']).toEqual(jasmine.any(Function));
-                expect(prechecksPromise['error']).toEqual(jasmine.any(Function));
-                expect(prechecksPromise['success']).toEqual(jasmine.any(Function));
+                expect(backupPromise).toEqual(jasmine.any(Object));
+                expect(backupPromise['then']).toEqual(jasmine.any(Function));
+                expect(backupPromise['catch']).toEqual(jasmine.any(Function));
+                expect(backupPromise['finally']).toEqual(jasmine.any(Function));
+                expect(backupPromise['error']).toEqual(jasmine.any(Function));
+                expect(backupPromise['success']).toEqual(jasmine.any(Function));
             });
 
-            // Prechecks success, partially passing and/or failing are handled in the controller.
-            it('when resolved, it returns the prechecks response', function () {
-                prechecksPromise.then(function (prechecksResponse) {
-                    expect(prechecksResponse.status).toEqual(200);
-                    assert.isFalse(prechecksResponse.config.cache);
-                    expect(prechecksResponse.config.responseType).toEqual('arraybuffer');
-                    expect(prechecksResponse.data).toEqual(mockedBackupFile);
+            // backup create success, partially passing and/or failing are handled in the controller.
+            it('when resolved, it returns the backup response', function () {
+                backupPromise.then(function (backupResponse) {
+                    expect(backupResponse.status).toEqual(200);
+                    expect(backupResponse.data).toEqual(mockedCreateResponse);
                 });
             });
-
         });
-        
+
+        describe('when download method is executed', function () {
+
+            beforeEach(function () {
+                $httpBackend.expect('GET', '/api/crowbar/backups/42/download')
+                    .respond(200, mockedBackupFile);
+                backupPromise = upgradeBackupFactory.download(42);
+                $httpBackend.flush();
+            });
+
+            it('returns a promise', function () {
+                expect(backupPromise).toEqual(jasmine.any(Object));
+                expect(backupPromise['then']).toEqual(jasmine.any(Function));
+                expect(backupPromise['catch']).toEqual(jasmine.any(Function));
+                expect(backupPromise['finally']).toEqual(jasmine.any(Function));
+                expect(backupPromise['error']).toEqual(jasmine.any(Function));
+                expect(backupPromise['success']).toEqual(jasmine.any(Function));
+            });
+
+            // backup download success, partially passing and/or failing are handled in the controller.
+            it('when resolved, it returns the backup response', function () {
+                backupPromise.then(function (backupResponse) {
+                    expect(backupResponse.status).toEqual(200);
+                    assert.isFalse(backupResponse.config.cache);
+                    expect(backupResponse.config.responseType).toEqual('arraybuffer');
+                    expect(backupResponse.data).toEqual(mockedBackupFile);
+                });
+            });
+        });
+
+        describe('when download method is executed without parameter', function () {
+
+            it('throws an exception', function () {
+                expect(upgradeBackupFactory.download).toThrow();
+            });
+        });
     });
+
+
 
 });


### PR DESCRIPTION
Modified the logic to match the two-step backup creation and download implemented in the API.

The backup (and file) name required by the API is auto-generated in format: `upgrade-backup-yyyyMMddHHmmss.tar.gz`.
