### PR TITLE
Update rsync script and options

### DIFF
--- a/gulp/rsync.js
+++ b/gulp/rsync.js
@@ -9,8 +9,7 @@ var gulp = require('gulp'),
     syncClouds = syncCloudConfig ? syncCloudConfig.clouds : {},
     syncCloud = syncClouds ? syncClouds[syncCloudID] : undefined,
 
-    skypeRsync = 'Skypping rsync.';
-
+    skypeRsync = 'Skipping rsync.';
 
 gulp.task('rsync', function () {
     // Skip rsync option
@@ -53,6 +52,5 @@ gulp.task('rsync', function () {
                 recursive: true,
                 silent: !syncCloudConfig.options.verbose
             }));
-
     }
 });

--- a/gulp/rsync.js
+++ b/gulp/rsync.js
@@ -3,20 +3,45 @@ var gulp = require('gulp'),
     gutil = require('gulp-util'),
     rsync = require('gulp-rsync'),
     optional = require('optional'),
-    syncCloudConfig = optional('./cloud.conf.json') || {},
+    syncCloudConfig = optional('./cloud.conf.json'),
     syncCloudID = gutil.env['sync-cloud'] || 'default',
-    syncClouds = syncCloudConfig.clouds || {},
-    syncCloud = syncClouds[syncCloudID];
+    noSync = gutil.env['no-sync'] || false,
+    syncClouds = syncCloudConfig ? syncCloudConfig.clouds : {},
+    syncCloud = syncClouds ? syncClouds[syncCloudID] : undefined,
+
+    skypeRsync = 'Skypping rsync.';
 
 
 gulp.task('rsync', function () {
-    if (syncCloud) {
+    // Skip rsync option
+    if (noSync) {
+        gutil.log(gutil.colors.yellow(skypeRsync));
+
+    // Missing cloud.config.json file
+    } else if (!syncCloudConfig) {
+        gutil.log(gutil.colors.yellow('Configuration file cloud.config.json not found.', skypeRsync));
+
+    // cloud.config.json file exists, but doesn't contain a 'clouds' attribute
+    } else if (typeof syncCloudConfig.clouds === 'undefined') {
+        gutil.log(gutil.colors.red('Missing clouds on configuration file', skypeRsync));
+
+    // The specified cloud doesn't exist in cloud.config.json file
+    } else if (typeof syncCloud === 'undefined') {
+        gutil.log(gutil.colors.red('Undefined configuration for cloud: ' + syncCloudID, skypeRsync));
+
+    // A non-string host has been specified
+    } else if (typeof syncCloud.host !== 'string') {
+        gutil.log(gutil.colors.red('No valid host specified for curent cloud: ' + syncCloudID, skypeRsync));
+
+    } else {
         // fallback to default port if not defined
         syncCloud.port = syncCloud.port || 22;
 
-        gutil.log('syncing with ' + syncCloudID +
-            ' cloud: ' + syncCloud.host +
-            ':' + syncCloud.port  + '...');
+        gutil.log(
+            gutil.colors.green('syncing with ' + syncCloudID +
+                ' cloud: ' + syncCloud.host +
+                ':' + syncCloud.port  + '...')
+        );
 
         return gulp.src('public/**')
             .pipe(rsync({
@@ -28,5 +53,6 @@ gulp.task('rsync', function () {
                 recursive: true,
                 silent: !syncCloudConfig.options.verbose
             }));
+
     }
 });

--- a/gulp/rsync.js
+++ b/gulp/rsync.js
@@ -9,28 +9,28 @@ var gulp = require('gulp'),
     syncClouds = syncCloudConfig ? syncCloudConfig.clouds : {},
     syncCloud = syncClouds ? syncClouds[syncCloudID] : undefined,
 
-    skypeRsync = 'Skipping rsync.';
+    skipeRsync = 'Skipping rsync.';
 
 gulp.task('rsync', function () {
     // Skip rsync option
     if (noSync) {
-        gutil.log(gutil.colors.yellow(skypeRsync));
+        gutil.log(gutil.colors.yellow(skipeRsync));
 
     // Missing cloud.config.json file
     } else if (!syncCloudConfig) {
-        gutil.log(gutil.colors.yellow('Configuration file cloud.config.json not found.', skypeRsync));
+        gutil.log(gutil.colors.yellow('Configuration file cloud.config.json not found.', skipeRsync));
 
     // cloud.config.json file exists, but doesn't contain a 'clouds' attribute
     } else if (typeof syncCloudConfig.clouds === 'undefined') {
-        gutil.log(gutil.colors.red('Missing clouds on configuration file', skypeRsync));
+        gutil.log(gutil.colors.red('Missing clouds on configuration file', skipeRsync));
 
     // The specified cloud doesn't exist in cloud.config.json file
     } else if (typeof syncCloud === 'undefined') {
-        gutil.log(gutil.colors.red('Undefined configuration for cloud: ' + syncCloudID, skypeRsync));
+        gutil.log(gutil.colors.red('Undefined configuration for cloud: ' + syncCloudID, skipeRsync));
 
     // A non-string host has been specified
     } else if (typeof syncCloud.host !== 'string') {
-        gutil.log(gutil.colors.red('No valid host specified for curent cloud: ' + syncCloudID, skypeRsync));
+        gutil.log(gutil.colors.red('No valid host specified for curent cloud: ' + syncCloudID, skipeRsync));
 
     } else {
         // fallback to default port if not defined

--- a/gulp/rsync.js
+++ b/gulp/rsync.js
@@ -9,28 +9,28 @@ var gulp = require('gulp'),
     syncClouds = syncCloudConfig ? syncCloudConfig.clouds : {},
     syncCloud = syncClouds ? syncClouds[syncCloudID] : undefined,
 
-    skipeRsync = 'Skipping rsync.';
+    skipRsync = 'Skipping rsync.';
 
 gulp.task('rsync', function () {
     // Skip rsync option
     if (noSync) {
-        gutil.log(gutil.colors.yellow(skipeRsync));
+        gutil.log(gutil.colors.yellow(skipRsync));
 
     // Missing cloud.config.json file
     } else if (!syncCloudConfig) {
-        gutil.log(gutil.colors.yellow('Configuration file cloud.config.json not found.', skipeRsync));
+        gutil.log(gutil.colors.yellow('Configuration file cloud.config.json not found.', skipRsync));
 
     // cloud.config.json file exists, but doesn't contain a 'clouds' attribute
     } else if (typeof syncCloudConfig.clouds === 'undefined') {
-        gutil.log(gutil.colors.red('Missing clouds on configuration file', skipeRsync));
+        gutil.log(gutil.colors.red('Missing clouds on configuration file', skipRsync));
 
     // The specified cloud doesn't exist in cloud.config.json file
     } else if (typeof syncCloud === 'undefined') {
-        gutil.log(gutil.colors.red('Undefined configuration for cloud: ' + syncCloudID, skipeRsync));
+        gutil.log(gutil.colors.red('Undefined configuration for cloud: ' + syncCloudID, skipRsync));
 
     // A non-string host has been specified
     } else if (typeof syncCloud.host !== 'string') {
-        gutil.log(gutil.colors.red('No valid host specified for curent cloud: ' + syncCloudID, skipeRsync));
+        gutil.log(gutil.colors.red('No valid host specified for curent cloud: ' + syncCloudID, skipRsync));
 
     } else {
         // fallback to default port if not defined


### PR DESCRIPTION
New `--no-sync=true/false` option added to skip remote synchronisation completely.
Add new error handlers around the configuration file and its cloud options
