### PR TITLE
S49P19 #32 Admin Server Repo Checks: Service Integration

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.js
@@ -13,10 +13,12 @@
             UpgradeAdministrationRepositoriesCheckController);
 
     UpgradeAdministrationRepositoriesCheckController.$inject = [
-        '$translate', 'crowbarFactory', 'ADMIN_REPO_CHECKS_MAP'
+        '$translate', 'crowbarFactory', 'PRODUCTS_REPO_CHECKS_MAP'
     ];
     // @ngInject
-    function UpgradeAdministrationRepositoriesCheckController($translate, crowbarFactory, ADMIN_REPO_CHECKS_MAP) {
+    function UpgradeAdministrationRepositoriesCheckController(
+        $translate, crowbarFactory, PRODUCTS_REPO_CHECKS_MAP
+    ) {
         var vm = this;
         vm.repoChecks = {
             running: false,
@@ -24,21 +26,21 @@
             completed: false,
             valid: false,
             checks: {
-                'SLES-12-SP2': {
+                'SLES12-SP2-Pool': {
                     status: false,
-                    label: 'upgrade.steps.admin-repository-checks.repositories.codes.SLES_12_SP2'
+                    label: 'upgrade.steps.admin-repository-checks.repositories.codes.SLES12-SP2-Pool'
                 },
-                'SLES-12-SP2-Updates': {
+                'SLES12-SP2-Updates': {
                     status: false,
-                    label: 'upgrade.steps.admin-repository-checks.repositories.codes.SLES_12_SP2_Updates'
+                    label: 'upgrade.steps.admin-repository-checks.repositories.codes.SLES12-SP2-Updates'
                 },
-                'SLES-OpenStack-Cloud-7': {
+                'SUSE-OpenStack-Cloud-7-Pool': {
                     status: false,
-                    label: 'upgrade.steps.admin-repository-checks.repositories.codes.SLES_OpenStack_Cloud_7'
+                    label: 'upgrade.steps.admin-repository-checks.repositories.codes.SUSE-OpenStack-Cloud-7-Pool'
                 },
-                'SLES-OpenStack-Cloud-7-Updates': {
+                'SUSE-OpenStack-Cloud-7-Updates': {
                     status: false,
-                    label: 'upgrade.steps.admin-repository-checks.repositories.codes.SLES_OpenStack_Cloud_7_Updates'
+                    label: 'upgrade.steps.admin-repository-checks.repositories.codes.SUSE-OpenStack-Cloud-7-Updates'
                 }
             },
             runRepoChecks: runRepoChecks
@@ -55,10 +57,13 @@
                     // In case of success
                     function (repoChecksResponse) {
                         // Iterate over our map
-                        _.forEach(ADMIN_REPO_CHECKS_MAP, function (repos, type) {
-                            _.forEach(repos, function(repo) {
-                                vm.repoChecks.checks[repo].status = repoChecksResponse.data[type]['available']
-                            });
+                        _.forEach(PRODUCTS_REPO_CHECKS_MAP, function (repos, type) {
+                            // Admin repochecks only checks for os or openstack repos
+                            if(type == 'os' || type == 'openstack') {
+                                _.forEach(repos, function(repo) {
+                                    vm.repoChecks.checks[repo].status = repoChecksResponse.data[type].available
+                                });
+                            }
                         });
                         // Iterate over the checks to determine the validity of the step
                         vm.repoChecks.valid = Object.keys(vm.repoChecks.checks).every(function(k) {

--- a/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.js
@@ -12,9 +12,11 @@
         .controller('UpgradeAdministrationRepositoriesCheckController',
             UpgradeAdministrationRepositoriesCheckController);
 
-    UpgradeAdministrationRepositoriesCheckController.$inject = ['$translate', 'crowbarFactory'];
+    UpgradeAdministrationRepositoriesCheckController.$inject = [
+        '$translate', 'crowbarFactory', 'ADMIN_REPO_CHECKS_MAP'
+    ];
     // @ngInject
-    function UpgradeAdministrationRepositoriesCheckController($translate, crowbarFactory) {
+    function UpgradeAdministrationRepositoriesCheckController($translate, crowbarFactory, ADMIN_REPO_CHECKS_MAP) {
         var vm = this;
         vm.repoChecks = {
             running: false,
@@ -22,19 +24,19 @@
             completed: false,
             valid: false,
             checks: {
-                'SLES_12_SP2': {
+                'SLES-12-SP2': {
                     status: false,
                     label: 'upgrade.steps.admin-repository-checks.repositories.codes.SLES_12_SP2'
                 },
-                'SLES_12_SP2_Updates': {
+                'SLES-12-SP2-Updates': {
                     status: false,
                     label: 'upgrade.steps.admin-repository-checks.repositories.codes.SLES_12_SP2_Updates'
                 },
-                'SLES_OpenStack_Cloud_7': {
+                'SLES-OpenStack-Cloud-7': {
                     status: false,
                     label: 'upgrade.steps.admin-repository-checks.repositories.codes.SLES_OpenStack_Cloud_7'
                 },
-                'SLES_OpenStack_Cloud_7_Updates': {
+                'SLES-OpenStack-Cloud-7-Updates': {
                     status: false,
                     label: 'upgrade.steps.admin-repository-checks.repositories.codes.SLES_OpenStack_Cloud_7_Updates'
                 }
@@ -52,27 +54,22 @@
                 .then(
                     // In case of success
                     function (repoChecksResponse) {
-
-                        _.forEach(repoChecksResponse.data, function(value, key) {
-                            vm.repoChecks.checks[key].status = value;
+                        // Iterate over our map
+                        _.forEach(ADMIN_REPO_CHECKS_MAP, function (repos, type) {
+                            _.forEach(repos, function(repo) {
+                                vm.repoChecks.checks[repo].status = repoChecksResponse.data[type]['available']
+                            });
                         });
-
-                        var repoChecksResult = true;
-                        // Update prechecks status
-
-                        _.forEach(vm.repoChecks.checks, function (repoStatus) {
-                            if (false === repoStatus.status) {
-                                repoChecksResult = false;
-                                return false;
-                            }
+                        // Iterate over the checks to determine the validity of the step
+                        vm.repoChecks.valid = Object.keys(vm.repoChecks.checks).every(function(k) {
+                            return vm.repoChecks.checks[k].status === true
                         });
-
-                        // Update prechecks validity
-                        vm.repoChecks.valid = repoChecksResult;
                     },
                     // In case of failure
                     function (errorRepoChecksResponse) {
                         // Expose the error list to repoChecks object
+                        // TODO(itxaka): Check the proper error response when the card is done
+                        // https://trello.com/c/chzg85j4/142-3-s49p7-error-reporting-on-crowbar-level
                         vm.repoChecks.errors = errorRepoChecksResponse.data.errors;
                     }
                 )

--- a/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.spec.js
@@ -1,4 +1,4 @@
-/*global bard $controller $httpBackend should assert crowbarFactory $q $rootScope */
+/*global bard $controller $httpBackend should assert crowbarFactory $q $rootScope PRODUCTS_REPO_CHECKS_MAP*/
 describe('Upgrade Flow - Admin Repositories Checks Controller', function () {
     var controller,
         passingRepoChecks = {
@@ -46,7 +46,10 @@ describe('Upgrade Flow - Admin Repositories Checks Controller', function () {
     beforeEach(function() {
         //Setup the module and dependencies to be used.
         bard.appModule('crowbarApp');
-        bard.inject('$controller', 'crowbarFactory', '$q', '$httpBackend', '$rootScope', 'ADMIN_REPO_CHECKS_MAP');
+        bard.inject(
+            '$controller', 'crowbarFactory', '$q', '$httpBackend',
+            '$rootScope', 'PRODUCTS_REPO_CHECKS_MAP'
+        );
 
         //Create the controller
         controller = $controller('UpgradeAdministrationRepositoriesCheckController');
@@ -165,13 +168,14 @@ describe('Upgrade Flow - Admin Repositories Checks Controller', function () {
 
             it('should update checks values to true or false as per the response', function () {
                 assert.isObject(controller.repoChecks.checks);
-                /* eslint-disable no-undef */
-                _.forEach(ADMIN_REPO_CHECKS_MAP, function(repos, type) {
-                /* eslint-enable no-undef */
-                    _.forEach(repos, function(repo) {
-                        expect(controller.repoChecks.checks[repo].status)
-                            .toEqual(partiallyFailingChecksResponse.data[type]['available'])
-                    });
+                _.forEach(PRODUCTS_REPO_CHECKS_MAP, function(repos, type) {
+                    // Admin repochecks only checks for os or openstack repos
+                    if (type == 'os' || type == 'openstack') {
+                        _.forEach(repos, function (repo) {
+                            expect(controller.repoChecks.checks[repo].status)
+                                .toEqual(partiallyFailingChecksResponse.data[type].available)
+                        });
+                    }
                 });
             });
         });

--- a/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.spec.js
@@ -2,22 +2,28 @@
 describe('Upgrade Flow - Admin Repositories Checks Controller', function () {
     var controller,
         passingRepoChecks = {
-            SLES_12_SP2: true,
-            SLES_12_SP2_Updates: true,
-            SLES_OpenStack_Cloud_7: true,
-            SLES_OpenStack_Cloud_7_Updates: true
+            os: {
+                available: true
+            },
+            openstack: {
+                available: true
+            }
         },
         failingRepoChecks = {
-            SLES_12_SP2: false,
-            SLES_12_SP2_Updates: false,
-            SLES_OpenStack_Cloud_7: false,
-            SLES_OpenStack_Cloud_7_Updates: false
+            os: {
+                available: false
+            },
+            openstack: {
+                available: false
+            }
         },
         partiallyFailingRepoChecks = {
-            SLES_12_SP2: true,
-            SLES_12_SP2_Updates: true,
-            SLES_OpenStack_Cloud_7: false,
-            SLES_OpenStack_Cloud_7_Updates: false
+            os: {
+                available: true
+            },
+            openstack: {
+                available: false
+            }
         },
         failingErrors = {
             error_message: 'Authentication failure'
@@ -40,7 +46,7 @@ describe('Upgrade Flow - Admin Repositories Checks Controller', function () {
     beforeEach(function() {
         //Setup the module and dependencies to be used.
         bard.appModule('crowbarApp');
-        bard.inject('$controller', 'crowbarFactory', '$q', '$httpBackend', '$rootScope');
+        bard.inject('$controller', 'crowbarFactory', '$q', '$httpBackend', '$rootScope', 'ADMIN_REPO_CHECKS_MAP');
 
         //Create the controller
         controller = $controller('UpgradeAdministrationRepositoriesCheckController');
@@ -159,8 +165,13 @@ describe('Upgrade Flow - Admin Repositories Checks Controller', function () {
 
             it('should update checks values to true or false as per the response', function () {
                 assert.isObject(controller.repoChecks.checks);
-                _.forEach(partiallyFailingChecksResponse.data, function(value, key) {
-                    expect(controller.repoChecks.checks[key].status).toEqual(value);
+                /* eslint-disable no-undef */
+                _.forEach(ADMIN_REPO_CHECKS_MAP, function(repos, type) {
+                /* eslint-enable no-undef */
+                    _.forEach(repos, function(repo) {
+                        expect(controller.repoChecks.checks[repo].status)
+                            .toEqual(partiallyFailingChecksResponse.data[type]['available'])
+                    });
                 });
             });
         });

--- a/assets/app/features/upgrade/controllers/upgrade-nodes-repositories-checks.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-nodes-repositories-checks.controller.js
@@ -15,14 +15,14 @@
         '$translate',
         'upgradeFactory',
         'crowbarFactory',
-        'NODES_PRODUCTS_REPO_CHECKS_MAP'
+        'PRODUCTS_REPO_CHECKS_MAP'
     ];
     // @ngInject
     function UpgradeNodesRepositoriesCheckController(
         $translate,
         upgradeFactory,
         crowbarFactory,
-        NODES_PRODUCTS_REPO_CHECKS_MAP
+        PRODUCTS_REPO_CHECKS_MAP
     ) {
         var vm = this,
             addonsRepos = {
@@ -78,7 +78,7 @@
             crowbarFactory.getEntity().then(function (entityResponse) {
                 if (! _.isEmpty(entityResponse.data.addons)) {
                     _.forEach(entityResponse.data.addons, function (addon) {
-                        _.forEach(NODES_PRODUCTS_REPO_CHECKS_MAP[addon], function (addonRepository) {
+                        _.forEach(PRODUCTS_REPO_CHECKS_MAP[addon], function (addonRepository) {
                             _.set(vm.repoChecks.checks, addonRepository, addonsRepos[addonRepository]);
                         });
 
@@ -119,10 +119,10 @@
             _.forEach(repoChecksResponse.data, function(productValue, productKey) {
 
                 // Validate a valid check from the service is being updated
-                if (NODES_PRODUCTS_REPO_CHECKS_MAP.hasOwnProperty(productKey)) {
+                if (PRODUCTS_REPO_CHECKS_MAP.hasOwnProperty(productKey)) {
 
                     // Iterate through the repositories list for the product
-                    _.forEach(NODES_PRODUCTS_REPO_CHECKS_MAP[productKey], function (repoName) {
+                    _.forEach(PRODUCTS_REPO_CHECKS_MAP[productKey], function (repoName) {
 
                         // If the product is available, then its related repositories should be displayed as passing
                         if (productValue.available) {

--- a/assets/app/features/upgrade/controllers/upgrade-nodes-repositories-checks.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-nodes-repositories-checks.controller.spec.js
@@ -179,7 +179,7 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             '$q',
             '$httpBackend',
             '$rootScope',
-            'NODES_PRODUCTS_REPO_CHECKS_MAP'
+            'PRODUCTS_REPO_CHECKS_MAP'
         );
 
         bard.mockService(crowbarFactory, {

--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -41,10 +41,10 @@
                 "description": "Update the URLs of the following software repositories and click 'Check' to verify the repositories are available. When all repositories have been verified click on 'Next' to proceed.",
                 "repositories": {
                     "codes": {
-                        "SLES_12_SP2": "SUSE Linux Enterprise 12 SP2",
-                        "SLES_12_SP2_Updates": "SUSE Linux Enterprise 12 SP2 Updates",
-                        "SLES_OpenStack_Cloud_7": "SUSE Linux OpenStack Cloud 7",
-                        "SLES_OpenStack_Cloud_7_Updates": "SUSE Linux OpenStack Cloud 7 Updates"
+                        "SLES12-SP2-Pool": "SUSE Linux Enterprise 12 SP2",
+                        "SLES12-SP2-Updates": "SUSE Linux Enterprise 12 SP2 Updates",
+                        "SUSE-OpenStack-Cloud-7-Pool": "SUSE Linux OpenStack Cloud 7",
+                        "SUSE-OpenStack-Cloud-7-Updates": "SUSE Linux OpenStack Cloud 7 Updates"
                     }
                 },
                 "form": {

--- a/assets/app/features/upgrade/upgrade.constants.js
+++ b/assets/app/features/upgrade/upgrade.constants.js
@@ -7,5 +7,9 @@
             'ha': ['SLE12-SP2-HA-Pool', 'SLE12-SP2-HA-Updates'],
             'openstack': ['SUSE-OpenStack-Cloud-7-Pool', 'SUSE-OpenStack-Cloud-7-Updates'],
             'ceph': ['SUSE-Enterprise-Storage-4-Pool', 'SUSE-Enterprise-Storage-4-Updates']
+        })
+        .constant('ADMIN_REPO_CHECKS_MAP', {
+            'os': ['SLES-12-SP2', 'SLES-12-SP2-Updates'],
+            'openstack': ['SLES-OpenStack-Cloud-7','SLES-OpenStack-Cloud-7-Updates']
         });
 })();

--- a/assets/app/features/upgrade/upgrade.constants.js
+++ b/assets/app/features/upgrade/upgrade.constants.js
@@ -2,14 +2,10 @@
 
     angular
         .module('crowbarApp.upgrade')
-        .constant('NODES_PRODUCTS_REPO_CHECKS_MAP', {
+        .constant('PRODUCTS_REPO_CHECKS_MAP', {
             'os': ['SLES12-SP2-Pool', 'SLES12-SP2-Updates'],
             'ha': ['SLE12-SP2-HA-Pool', 'SLE12-SP2-HA-Updates'],
             'openstack': ['SUSE-OpenStack-Cloud-7-Pool', 'SUSE-OpenStack-Cloud-7-Updates'],
             'ceph': ['SUSE-Enterprise-Storage-4-Pool', 'SUSE-Enterprise-Storage-4-Updates']
-        })
-        .constant('ADMIN_REPO_CHECKS_MAP', {
-            'os': ['SLES-12-SP2', 'SLES-12-SP2-Updates'],
-            'openstack': ['SLES-OpenStack-Cloud-7','SLES-OpenStack-Cloud-7-Updates']
         });
 })();

--- a/routes/api/crowbar/repocheck.js
+++ b/routes/api/crowbar/repocheck.js
@@ -1,6 +1,6 @@
 var express = require('express'),
-    router = express.Router();
-var repo_correct = false;
+    router = express.Router(),
+    repo_correct = false;
 
 /* GET Admin Repo Checks. */
 router.get('/', function(req, res) {
@@ -9,7 +9,7 @@ router.get('/', function(req, res) {
             'available': true,
             'repos': {}
         },
-        'cloud': {
+        'openstack': {
             'available': false,
             'repos': {
                 'x86_64': {
@@ -23,7 +23,7 @@ router.get('/', function(req, res) {
     };
 
     if (repo_correct) {
-        data['cloud'] = {
+        data['openstack'] = {
             'available': true,
             'repos': {}
         }

--- a/routes/api/crowbar/repocheck.js
+++ b/routes/api/crowbar/repocheck.js
@@ -14,8 +14,8 @@ router.get('/', function(req, res) {
             'repos': {
                 'x86_64': {
                     'missing': [
-                        'SUSE OpenStack Cloud 7',
-                        'SUSE OpenStack Cloud 7 Updates'
+                        'SUSE-OpenStack-Cloud-7-Pool',
+                        'SUSE-OpenStack-Cloud-7-Updates'
                     ]
                 }
             }

--- a/routes/api/crowbar/repocheck.js
+++ b/routes/api/crowbar/repocheck.js
@@ -1,14 +1,35 @@
 var express = require('express'),
     router = express.Router();
+var repo_correct = false;
 
 /* GET Admin Repo Checks. */
 router.get('/', function(req, res) {
-    res.status(200).json({
-        'SLES_12_SP2': true,
-        'SLES_12_SP2_Updates': true,
-        'SLES_OpenStack_Cloud_7': true,
-        'SLES_OpenStack_Cloud_7_Updates': true
-    });
+    var data = {
+        'os': {
+            'available': true,
+            'repos': {}
+        },
+        'cloud': {
+            'available': false,
+            'repos': {
+                'x86_64': {
+                    'missing': [
+                        'SUSE OpenStack Cloud 7',
+                        'SUSE OpenStack Cloud 7 Updates'
+                    ]
+                }
+            }
+        }
+    };
+
+    if (repo_correct) {
+        data['cloud'] = {
+            'available': true,
+            'repos': {}
+        }
+    }
+    repo_correct = !repo_correct;
+    res.status(200).json(data);
 });
 
 module.exports = router;


### PR DESCRIPTION
- Acomodate the code to the actual API response
- Create a static fake api call to test the admin repocheck page
- Acomodate the tests to the changes
- Sync test data with API response
- Change the repo keys to be in sync with how we use them on the node repo checks
- Acomodate the controller to deal with the API returning a products view rather than a per-repo response.
