### PR TITLE
Increase test coverage of upgrade.controller.js

### DIFF
--- a/assets/app/features/upgrade/upgrade.controller.spec.js
+++ b/assets/app/features/upgrade/upgrade.controller.spec.js
@@ -25,7 +25,7 @@ describe('Upgrade Controller', function () {
         });
 
         // set current state
-        $state.current  = {name: 'test1', id: 0, active: true, state: 'state1'};
+        $state.current  = {name: 'state1', id: 0, active: true};
         scope = $rootScope.$new();
 
         //Create the controller
@@ -47,6 +47,12 @@ describe('Upgrade Controller', function () {
 
         it('should have a step list', function() {
             should.exist(controller.steps.list);
+        });
+
+        it('should have the default activeStep', function () {
+            should.exist(controller.steps.activeStep);
+            expect(controller.steps.activeStep.enabled).toBe(true);
+            expect(controller.steps.activeStep.id).toEqual(0);
         });
 
         describe('nextStep function', function () {
@@ -84,18 +90,13 @@ describe('Upgrade Controller', function () {
             });
 
             it('after moving to last step should return true', function () {
-                expect(controller.steps.activeStep.id).toEqual(0);
-                for (var i = 0; i < (stepsList.length - 1); i++) {
-                    controller.steps.nextStep();
-                }
-                expect(controller.steps.activeStep.id).toEqual(lastStep.id);
+                // set current and activeStep to the last one
+                $state.current = lastStep;
+                controller.steps.activeStep = lastStep;
                 assert.isTrue(controller.steps.isLastStep());
             })
         });
 
-        xdescribe('refeshStepsList function', function () {
-
-        })
     });
 
     //@TODO: Implement the following tests

--- a/assets/app/features/upgrade/upgrade.controller.spec.js
+++ b/assets/app/features/upgrade/upgrade.controller.spec.js
@@ -1,7 +1,105 @@
+/*global bard $controller should $httpBackend upgradeStepsFactory assert $rootScope $state */
 describe('Upgrade Controller', function () {
+    var controller,
+        scope,
+        stepsList = [
+            {id: 0, title: 'first', active: false, enabled: false, state: 'state1' },
+            {id: 1, title: 'second', active: false, enabled: false, state: 'state2' },
+            {id: 2, title: 'third', active: false, enabled: false, state: 'state3' }
+        ],
+        lastStep = stepsList[stepsList.length - 1];
+
+    beforeEach(function() {
+        //Setup the module and dependencies to be used.
+        bard.appModule('crowbarApp');
+        bard.inject('$controller', '$rootScope', '$httpBackend', '$state', 'upgradeStepsFactory');
+
+        // mock the factory
+        bard.mockService(upgradeStepsFactory, {
+            getAll: stepsList
+        });
+
+        // Mock the state
+        bard.mockService($state, {
+            go: true
+        });
+
+        // set current state
+        $state.current  = {name: 'test1', id: 0, active: true, state: 'state1'};
+        scope = $rootScope.$new();
+
+        //Create the controller
+        controller = $controller('UpgradeController', {$scope: scope});
+
+        //Mock requests that are expected to be made
+        $httpBackend.expectGET('app/features/upgrade/i18n/en.json').respond({});
+        $httpBackend.flush();
+
+    });
+
+    // Verify no unexpected http call has been made
+    bard.verifyNoOutstandingHttpRequests();
+
+    describe('UpgradeController', function () {
+        it('should exist', function () {
+            should.exist(controller);
+        });
+
+        it('should have a step list', function() {
+            should.exist(controller.steps.list);
+        });
+
+        describe('nextStep function', function () {
+            it('should be defined', function () {
+                should.exist(controller.steps.nextStep);
+                expect(controller.steps.nextStep).toEqual(jasmine.any(Function));
+            });
+
+            it('should change step when called', function () {
+                expect(controller.steps.activeStep.id).toEqual(0);
+                controller.steps.nextStep();
+                expect(controller.steps.activeStep.id).toEqual(1);
+
+            });
+
+            it('should not change step if we are on the last step', function () {
+                expect(controller.steps.activeStep.id).toEqual(0);
+                for (var i = 0; i < (stepsList.length - 1); i++) {
+                    controller.steps.nextStep();
+                }
+                expect(controller.steps.activeStep.id).toEqual(lastStep.id);
+                controller.steps.nextStep();
+                expect(controller.steps.activeStep.id).toEqual(lastStep.id);
+            })
+        });
+
+        describe('isLastStep function', function () {
+            it('should be defined', function () {
+                should.exist(controller.steps.isLastStep);
+                expect(controller.steps.isLastStep).toEqual(jasmine.any(Function));
+            });
+
+            it('on first step should return false', function () {
+                assert.isFalse(controller.steps.isLastStep());
+            });
+
+            it('after moving to last step should return true', function () {
+                expect(controller.steps.activeStep.id).toEqual(0);
+                for (var i = 0; i < (stepsList.length - 1); i++) {
+                    controller.steps.nextStep();
+                }
+                expect(controller.steps.activeStep.id).toEqual(lastStep.id);
+                assert.isTrue(controller.steps.isLastStep());
+            })
+        });
+
+        xdescribe('refeshStepsList function', function () {
+
+        })
+    });
 
     //@TODO: Implement the following tests
-    describe('cancelUpgrade function', function () {
+    xdescribe('cancelUpgrade function', function () {
         it('should be defined', function () {});
 
         it('should be enabled', function () {});


### PR DESCRIPTION
My first time adding this type of tests where you need to mock some services so not sure if everything is ok, so please check carefully. Thanks!

Still missing tests for refeshStepsList, they will come tomorrow in a new commit

Before:

```
=============================== Coverage summary ===============================
Statements   : 97.26% ( 1279/1315 )
Branches     : 81.48% ( 44/54 )
Functions    : 97.74% ( 519/531 )
Lines        : 97.26% ( 1279/1315 )
================================================================================
```

After

```
=============================== Coverage summary ===============================
Statements   : 99.04% ( 1347/1360 )
Branches     : 87.04% ( 47/54 )
Functions    : 97.98% ( 533/544 )
Lines        : 99.04% ( 1347/1360 )
================================================================================
```
