### PR TITLE
Make Coverage report and preprocessor optionals

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,10 @@
+// Determine wether of not coverage preprocessor should be used
+var isCoverageMode = function () {
+    return (process.argv.some(function (argument) {
+        return argument === '--coverage';
+    }));
+};
+
 // Karma configuration
 // Generated on Thu Aug 04 2016 14:03:14 GMT+0200 (CEST)
 
@@ -32,10 +39,6 @@ module.exports = function(config) {
         // preprocess matching files before serving them to the browser
         // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
         preprocessors: {
-            // source files, that you wanna generate coverage for
-            // do not include tests or libraries
-            // (these files will be instrumented by Istanbul)
-            'assets/app/**/*.js': ['coverage']
         },
 
         // optionally, configure the reporter
@@ -60,7 +63,7 @@ module.exports = function(config) {
         // test results reporter to use
         // possible values: 'dots', 'progress'
         // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-        reporters: ['progress', 'coverage'],
+        reporters: ['progress'],
 
 
         // web server port
@@ -93,5 +96,47 @@ module.exports = function(config) {
         // Concurrency level
         // how many browser should be started simultaneous
         concurrency: Infinity
-    })
+    });
+
+
+    // Coverage report will be generated
+    if (isCoverageMode()) {
+        config.set({
+            preprocessors: {
+                // source files, that you wanna generate coverage for
+                // do not include tests or libraries
+                // (these files will be instrumented by Istanbul)
+                'assets/app/**/*.js': ['coverage']
+            },
+
+            // optionally, configure the reporter
+            coverageReporter: {
+                type : 'html',
+                dir : 'coverage/',
+                check: {
+                    global: {
+                        statements: 80,
+                        branches: 80,
+                        functions: 80,
+                        lines: 80
+                    }
+                },
+                includeAllSources: true,
+                reporters:[
+                    {type: 'html', dir:'coverage/'},
+                    {type: 'text-summary'}
+                ],
+                instrumenterOptions: {
+                    istanbul: { noCompact: true }
+                }
+            },
+
+            // test results reporter to use
+            // possible values: 'dots', 'progress'
+            // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+            reporters: ['progress', 'coverage']
+
+        });
+
+    }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,9 +1,6 @@
 // Determine wether of not coverage preprocessor should be used
-var isCoverageMode = function () {
-    return (process.argv.some(function (argument) {
-        return argument === '--coverage';
-    }));
-};
+var gutil = require('gulp-util'),
+    isCoverageMode = gutil.env.hasOwnProperty('coverage');
 
 // Karma configuration
 // Generated on Thu Aug 04 2016 14:03:14 GMT+0200 (CEST)
@@ -100,7 +97,7 @@ module.exports = function(config) {
 
 
     // Coverage report will be generated
-    if (isCoverageMode()) {
+    if (isCoverageMode) {
         config.set({
             preprocessors: {
                 // source files, that you wanna generate coverage for

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www.js",
-    "test": "./node_modules/karma/bin/karma start karma.conf.js --single-run --browsers PhantomJS",
+    "test": "./node_modules/karma/bin/karma start karma.conf.js --single-run --browsers PhantomJS --coverage",
     "run-lints": "gulp lints"
   },
   "pre-commit": [


### PR DESCRIPTION
Due to coverage preprocessor, debugging unit tests with karma and chrome became harder.
Therefore, coverage report and preprocessors are now optionals under `--coverage` parameter.
See http://stackoverflow.com/questions/23560052/grunt-karma-debug-unminified-sources/34793572#34793572

`npm test` will run `./node_modules/karma/bin/karma start karma.conf.js --single-run --browsers PhantomJS --coverage`, which includes code coverage reports and gating.
`karma start --broesers Chrome` will run karma in Chrome browser if debug is required
