### PR TITLE
Updated landing page UI to match new prechecks API

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
@@ -104,7 +104,10 @@
                     function(response) {
 
                         _.forEach(response.data.checks, function(value, key) {
-                            vm.prechecks.checks[key].status = value.passed;
+                            // skip unknown checks returned from backend
+                            if (key in vm.prechecks.checks) {
+                                vm.prechecks.checks[key].status = value.passed;
+                            }
                         });
 
                         // Update prechecks validity

--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
@@ -103,24 +103,13 @@
                     //Success handler. Al precheck passed successfully:
                     function(response) {
 
-                        _.forEach(response.data, function(value, key) {
-                            // TODO: handle required vs not-required checks properly in the new design
-                            vm.prechecks.checks[key].status = value.passed || !value.required;
-                            vm.prechecks.checks[key].required = value.required;
-                        });
-
-                        var prechecksResult = true;
-
-                        // Update prechecks status
-                        _.forEach(vm.prechecks.checks, function (checkStatus) {
-                            if (!checkStatus.status) {
-                                prechecksResult = false;
-                                return false;
-                            }
+                        _.forEach(response.data.checks, function(value, key) {
+                            vm.prechecks.checks[key].status = value.passed;
                         });
 
                         // Update prechecks validity
-                        vm.prechecks.valid = prechecksResult;
+                        // TODO: handle disruptive vs non-disruptive properly in the new design
+                        vm.prechecks.valid = (response.data.best_method != 'none');
                     },
                     //Failure handler:
                     function(errorResponse) {

--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
@@ -27,13 +27,13 @@ describe('Upgrade Landing Controller', function() {
             error_message: 'Authentication failure'
         },
         passingChecksResponse = {
-            data: passingChecks
+            data: { checks: passingChecks, best_method: 'non-disruptive' }
         },
         failingChecksResponse = {
-            data: failingChecks
+            data: { checks: failingChecks, best_method: 'none' }
         },
         partiallyFailingChecksResponse = {
-            data: partiallyFailingChecks
+            data: { checks: partiallyFailingChecks, best_method: 'disruptive' }
         },
         failingResponse = {
             data: {
@@ -197,7 +197,7 @@ describe('Upgrade Landing Controller', function() {
                 });
             });
 
-            describe('when checks partially fails', function () {
+            describe('when checks partially fail', function () {
                 beforeEach(function () {
                     bard.mockService(upgradeFactory, {
                         getPreliminaryChecks: $q.when(partiallyFailingChecksResponse)
@@ -210,14 +210,14 @@ describe('Upgrade Landing Controller', function() {
                     assert.isTrue(controller.prechecks.completed);
                 });
 
-                it('should update valid attribute of checks model to false', function () {
-                    assert.isFalse(controller.prechecks.valid);
+                it('should update valid attribute of checks model to true (disruptive only)', function () {
+                    assert.isTrue(controller.prechecks.valid);
                 });
 
                 it('should update checks values to true or false as per the response', function () {
                     assert.isObject(controller.prechecks.checks);
-                    _.forEach(partiallyFailingChecksResponse.data, function(value, key) {
-                        expect(controller.prechecks.checks[key].status).toEqual(value.passed || !value.required);
+                    _.forEach(partiallyFailingChecksResponse.data.checks, function(value, key) {
+                        expect(controller.prechecks.checks[key].status).toEqual(value.passed);
                     });
                 });
             });

--- a/routes/api/upgrade/prechecks.js
+++ b/routes/api/upgrade/prechecks.js
@@ -11,11 +11,14 @@ router.get('/', function(req, res) {
     } else {
         // fail some checks first, then succeed on second call
         res.status(200).json({
-            'maintenance_updates_installed': { required: true, passed: true },
-            'network_checks': { required: true, passed: checksPass },
-            'clusters_healthy': { required: true, passed: true },
-            'ceph_healthy': { required: true, passed: checksPass },
-            'compute_resources_available': { required: false, passed: true }
+            'checks': {
+                'maintenance_updates_installed': { required: true, passed: true },
+                'network_checks': { required: true, passed: checksPass },
+                'clusters_healthy': { required: true, passed: true },
+                'ceph_healthy': { required: true, passed: checksPass },
+                'compute_resources_available': { required: false, passed: true }
+            },
+            'best_method': checksPass ? 'non-disruptive' : 'none'
         });
     }
     checksPass = true;


### PR DESCRIPTION
Prechecks were moved under 'checks' key and additional 'best_method'
attribute was added to hint the client/UI about the best possible
upgrade method available. The method is based on current result of
prechecks and installed addon products.

See: https://github.com/crowbar/crowbar-core/pull/746
