### PR TITLE
Use angular-file-saver for the download files

### DIFF
--- a/assets/app/core/crowbar-core.module.js
+++ b/assets/app/core/crowbar-core.module.js
@@ -5,7 +5,7 @@
         /*
          * Angular modules
          */
-        'ngAnimate', 'ngCookies', 'ngResource', 'ui.router', 'ngSanitize', 'ngTouch',
+        'ngAnimate', 'ngCookies', 'ngResource', 'ui.router', 'ngFileSaver', 'ngSanitize', 'ngTouch',
 
         /*
          * Our reusable cross app code modules

--- a/assets/app/data/crowbar/services/crowbar-utils.factory.js
+++ b/assets/app/data/crowbar/services/crowbar-utils.factory.js
@@ -28,7 +28,7 @@
             var requestOptions = {
                 method: 'GET',
                 cache: false,
-                responseType: 'arraybuffer',
+                responseType: 'blob',
                 url: '/utils/backups/' + id + '/download',
                 // this is not strictly needed here, but can be left for consistency
                 headers: COMMON_API_V1_HEADERS

--- a/assets/app/data/crowbar/services/crowbar-utils.factory.spec.js
+++ b/assets/app/data/crowbar/services/crowbar-utils.factory.spec.js
@@ -49,7 +49,7 @@ describe('Crowbar Utils Factory', function () {
                 backupPromise.then(function (backupResponse) {
                     expect(backupResponse.status).toEqual(200);
                     assert.isFalse(backupResponse.config.cache);
-                    expect(backupResponse.config.responseType).toEqual('arraybuffer');
+                    expect(backupResponse.config.responseType).toEqual('blob');
                     expect(backupResponse.data).toEqual(mockedBackupFile);
                 });
             });

--- a/assets/app/features/upgrade/controllers/upgrade-backup.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-backup.controller.js
@@ -81,14 +81,9 @@ function() {
                         var headers = response.headers(),
 
                             // Get the filename from the headers or default to "crowbarBackup"
-                            filename = extractFilename(headers) || 'crowbarBackup',
+                            filename = extractFilename(headers) || 'crowbarBackup';
 
-                            // Determine the content type from the header
-                            contentType = headers['content-type'],
-
-                            backupBlob = new Blob([response.data], {type: contentType});
-
-                        FileSaver.saveAs(backupBlob, filename)
+                        FileSaver.saveAs(response.data, filename)
                     },
                     // In case of download error
                     function (errorResponse) {

--- a/assets/app/features/upgrade/controllers/upgrade-backup.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-backup.controller.js
@@ -1,4 +1,4 @@
-(/*global Blob URL */
+(/*global */
 function() {
     'use strict';
 
@@ -18,7 +18,9 @@ function() {
         'crowbarUtilsFactory',
         '$document',
         'upgradeStepsFactory',
-        'upgradeFactory'
+        'upgradeFactory',
+        'FileSaver',
+        'Blob'
     ];
     // @ngInject
     function UpgradeBackupController(
@@ -27,7 +29,9 @@ function() {
         crowbarUtilsFactory,
         $document,
         upgradeStepsFactory,
-        upgradeFactory
+        upgradeFactory,
+        FileSaver,
+        Blob
     ) {
         var vm = this;
         vm.backup = {
@@ -82,18 +86,9 @@ function() {
                             // Determine the content type from the header
                             contentType = headers['content-type'],
 
-                            backupBlob = new Blob([response.data], {type: contentType}),
-                            backupObjectUrl = URL.createObjectURL(backupBlob),
+                            backupBlob = new Blob([response.data], {type: contentType});
 
-                            // Create download a DOM element
-                            backupElement = $document[0].createElement('a');
-
-                        // Set anchor properties
-                        backupElement.href = backupObjectUrl;
-                        backupElement.download = filename;
-
-                        // Trigger the download
-                        backupElement.click();
+                        FileSaver.saveAs(backupBlob, filename)
                     },
                     // In case of download error
                     function (errorResponse) {

--- a/assets/app/features/upgrade/controllers/upgrade-backup.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-backup.controller.js
@@ -30,8 +30,7 @@ function() {
         $document,
         upgradeStepsFactory,
         upgradeFactory,
-        FileSaver,
-        Blob
+        FileSaver
     ) {
         var vm = this;
         vm.backup = {

--- a/assets/app/features/upgrade/controllers/upgrade-backup.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-backup.controller.spec.js
@@ -10,9 +10,10 @@ describe('Upgrade Flow - Backup Controller', function() {
             data: { id: 42 }
         },
         mockedDownloadFile = '--Mock Backup File--',
+        mockedFileName = 'S33z8qFX.jpg.zip',
         mockedDownloadResponseHeaders = {
             'connection': 'keep-alive',
-            'content-disposition': 'attachment; filename=S33z8qFX.jpg.zip',
+            'content-disposition': 'attachment; filename=' + mockedFileName,
             'content-type': 'application/zip',
             'date': 'Thu, 25 Aug 2016 11:07:32 GMT',
             'transfer-encoding': 'chunked',
@@ -156,7 +157,7 @@ describe('Upgrade Flow - Backup Controller', function() {
                         should.not.exist(controller.backup.error);
                     });
 
-                    it('uses the default name for the file', function () {
+                    it('calls saveAs with data received from the service and default filename', function () {
                         expect(FileSaver.saveAs).toHaveBeenCalledWith(
                           mockedDownloadResponse.data, 'crowbarBackup'
                         );
@@ -194,9 +195,9 @@ describe('Upgrade Flow - Backup Controller', function() {
                         should.not.exist(controller.backup.error);
                     });
 
-                    it('does not use the default name for the file', function () {
-                        expect(FileSaver.saveAs).not.toHaveBeenCalledWith(
-                          mockedDownloadResponse.data, 'crowbarBackup'
+                    it('calls saveAs with data received from the service and filename from header', function () {
+                        expect(FileSaver.saveAs).toHaveBeenCalledWith(
+                          mockedDownloadResponse.data, mockedFileName
                         );
                     })
                 });

--- a/assets/app/features/upgrade/controllers/upgrade-backup.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-backup.controller.spec.js
@@ -1,5 +1,5 @@
 /* jshint -W117, -W030 */
-/*global bard $controller $httpBackend should assert crowbarUtilsFactory $q $rootScope $document upgradeFactory */
+/*global bard $controller $httpBackend should assert crowbarBackupFactory $q $rootScope $document upgradeFactory Blob FileSaver */
 describe('Upgrade Flow - Backup Controller', function() {
     var controller,
         mockedErrorList = [ 1, 2, 3],
@@ -19,7 +19,7 @@ describe('Upgrade Flow - Backup Controller', function() {
             'x-powered-by': 'Express',
         },
         mockedDownloadResponse = {
-            data: mockedDownloadFile,
+            data: new Blob([mockedDownloadFile]),
             'headers': function() {}
         };
 
@@ -33,7 +33,8 @@ describe('Upgrade Flow - Backup Controller', function() {
             '$httpBackend',
             '$document',
             'upgradeFactory',
-            'crowbarUtilsFactory'
+            'crowbarUtilsFactory',
+            'FileSaver'
         );
 
         //Create the controller
@@ -123,17 +124,10 @@ describe('Upgrade Flow - Backup Controller', function() {
 
             describe('when executed', function () {
                 describe('on success with wrong file headers', function () {
-                    var downloadBackupMock;
 
                     beforeEach(function () {
 
-                        // Mock the click() method of a fake downloadBackup element
-                        downloadBackupMock = $document[0].createElement('a')
-                        spyOn(downloadBackupMock, 'click');
-
-                        // Mock the createElement() method of $document[0]
-                        spyOn($document[0], 'createElement')
-                            .and.returnValue(downloadBackupMock);
+                        spyOn(FileSaver, 'saveAs');
 
                         // Mock the headers() method of the fake response
                         spyOn(mockedDownloadResponse, 'headers')
@@ -150,14 +144,8 @@ describe('Upgrade Flow - Backup Controller', function() {
                         $rootScope.$digest();
                     });
 
-                    it('click() method should have been triggered to download the backup', function () {
-                        expect($document[0].createElement).toHaveBeenCalledWith('a');
-                        expect(downloadBackupMock.click).toHaveBeenCalled();
-                        expect(downloadBackupMock.click.calls.count()).toBe(1);
-                    });
-
-                    it('crowbarUtilsFactory.getAdminBackup() has been called once', function () {
-                        assert.isTrue(crowbarUtilsFactory.getAdminBackup.calledOnce);
+                    it('crowbarBackupFactory.get() has been called once', function () {
+                        assert.isTrue(crowbarBackupFactory.get.calledOnce);
                     });
 
                     it('changes the completed status', function() {
@@ -169,21 +157,15 @@ describe('Upgrade Flow - Backup Controller', function() {
                     });
 
                     it('uses the default name for the file', function () {
-                        expect(downloadBackupMock.download).toEqual('crowbarBackup');
+                        expect(FileSaver.saveAs).toHaveBeenCalledWith(
+                          mockedDownloadResponse.data, 'crowbarBackup'
+                        );
                     })
                 });
                 describe('on success', function () {
-                    var downloadBackupMock;
 
                     beforeEach(function () {
-
-                        // Mock the click() method of a fake downloadBackup element
-                        downloadBackupMock = $document[0].createElement('a');
-                        spyOn(downloadBackupMock, 'click');
-
-                        // Mock the createElement() method of $document[0]
-                        spyOn($document[0], 'createElement')
-                            .and.returnValue(downloadBackupMock);
+                        spyOn(FileSaver, 'saveAs');
 
                         // Mock the headers() method of the fake response
                         spyOn(mockedDownloadResponse, 'headers')
@@ -200,13 +182,8 @@ describe('Upgrade Flow - Backup Controller', function() {
                         $rootScope.$digest();
                     });
 
-                    it('click() method should have been triggered to download the backup', function () {
-                        expect($document[0].createElement).toHaveBeenCalledWith('a');
-                        expect(downloadBackupMock.click).toHaveBeenCalled();
-                    });
-
-                    it('crowbarUtilsFactory.getAdminBackup() has been called once', function () {
-                        assert.isTrue(crowbarUtilsFactory.getAdminBackup.calledOnce);
+                    it('crowbarBackupFactory.get() has been called once', function () {
+                        assert.isTrue(crowbarBackupFactory.get.calledOnce);
                     });
 
                     it('changes the completed status', function() {
@@ -218,7 +195,9 @@ describe('Upgrade Flow - Backup Controller', function() {
                     });
 
                     it('does not use the default name for the file', function () {
-                        expect(downloadBackupMock.download).not.toEqual('crowbarBackup');
+                        expect(FileSaver.saveAs).not.toHaveBeenCalledWith(
+                          mockedDownloadResponse.data, 'crowbarBackup'
+                        );
                     })
                 });
 

--- a/assets/app/features/upgrade/controllers/upgrade-backup.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-backup.controller.spec.js
@@ -1,5 +1,5 @@
 /* jshint -W117, -W030 */
-/*global bard $controller $httpBackend should assert crowbarBackupFactory $q $rootScope $document upgradeFactory Blob FileSaver */
+/*global bard $controller $httpBackend should assert $q $rootScope upgradeFactory Blob FileSaver crowbarUtilsFactory */
 describe('Upgrade Flow - Backup Controller', function() {
     var controller,
         mockedErrorList = [ 1, 2, 3],
@@ -17,7 +17,7 @@ describe('Upgrade Flow - Backup Controller', function() {
             'content-type': 'application/zip',
             'date': 'Thu, 25 Aug 2016 11:07:32 GMT',
             'transfer-encoding': 'chunked',
-            'x-powered-by': 'Express',
+            'x-powered-by': 'Express'
         },
         mockedDownloadResponse = {
             data: new Blob([mockedDownloadFile]),
@@ -32,7 +32,6 @@ describe('Upgrade Flow - Backup Controller', function() {
             '$rootScope',
             '$q',
             '$httpBackend',
-            '$document',
             'upgradeFactory',
             'crowbarUtilsFactory',
             'FileSaver'
@@ -145,8 +144,8 @@ describe('Upgrade Flow - Backup Controller', function() {
                         $rootScope.$digest();
                     });
 
-                    it('crowbarBackupFactory.get() has been called once', function () {
-                        assert.isTrue(crowbarBackupFactory.get.calledOnce);
+                    it('crowbarUtilsFactory.getAdminBackup() has been called once', function () {
+                        assert.isTrue(crowbarUtilsFactory.getAdminBackup.calledOnce);
                     });
 
                     it('changes the completed status', function() {
@@ -183,8 +182,8 @@ describe('Upgrade Flow - Backup Controller', function() {
                         $rootScope.$digest();
                     });
 
-                    it('crowbarBackupFactory.get() has been called once', function () {
-                        assert.isTrue(crowbarBackupFactory.get.calledOnce);
+                    it('crowbarUtilsFactory.getAdminBackup() has been called once', function () {
+                        assert.isTrue(crowbarUtilsFactory.getAdminBackup.calledOnce);
                     });
 
                     it('changes the completed status', function() {

--- a/assets/app/features/upgrade/upgrade.module.js
+++ b/assets/app/features/upgrade/upgrade.module.js
@@ -2,5 +2,5 @@
     'use strict';
 
     angular
-        .module('crowbarApp.upgrade', ['ui.router', 'pascalprecht.translate', 'suseData']);
+        .module('crowbarApp.upgrade', ['ui.router', 'ngFileSaver', 'pascalprecht.translate', 'suseData']);
 })();

--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
     "angular-translate": "^2.11.0",
     "angular-ui-router": "^0.3.1",
     "angular-loading-bar": "^0.9.0",
+    "angular-file-saver": "^1.1.2",
     "bootstrap": "^3.3.6",
     "angular-bootstrap": "^2.0.1",
     "font-awesome": "^4.6.3",


### PR DESCRIPTION
As pointed by @skazi0 angular-file-saver makes the downloading stuff pretty easy and it works cross-browser, fixing https://github.com/crowbar/crowbar-ui/issues/32 and probably any other issue with IE browsers.

This is only a run test, tests doesn't pass and there is no new tests done for the different functionality but its so @santiph can weight on what he thinks about this and if we should go forward with this or not.
