### PR TITLE
Switch from /api/crowbar/upgrade to /api/upgrade.

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ var express = require('express'),
     crowbarEntity = require('./routes/api/crowbar/entity'),
     crowbarRepocheck = require('./routes/api/upgrade/adminrepocheck'),
     crowbarUpgrade = require('./routes/api/crowbar/upgrade'),
+    upgrade = require('./routes/api/upgrade'),
     upgradeRepocheck = require('./routes/api/upgrade/repocheck'),
     upgradePrechecks = require('./routes/api/upgrade/prechecks'),
     upgradePrepare = require('./routes/api/upgrade/prepare'),
@@ -31,6 +32,7 @@ app.use('/', index);
 app.use('/api/crowbar', crowbarEntity);
 app.use('/api/upgrade/adminrepocheck', crowbarRepocheck);
 app.use('/api/crowbar/upgrade', crowbarUpgrade);
+app.use('/api/upgrade', upgrade);
 app.use('/api/upgrade/prechecks', upgradePrechecks);
 app.use('/api/upgrade/repocheck', upgradeRepocheck);
 app.use('/api/upgrade/prepare', upgradePrepare);

--- a/assets/app/data/crowbar/services/upgrade.factory.js
+++ b/assets/app/data/crowbar/services/upgrade.factory.js
@@ -11,7 +11,8 @@
             getPreliminaryChecks: getPreliminaryChecks,
             prepareNodes: prepareNodes,
             getNodesRepoChecks: getNodesRepoChecks,
-            getRepositoriesChecks: getRepositoriesChecks
+            getRepositoriesChecks: getRepositoriesChecks,
+            getStatus: getStatus
         };
 
         return factory;
@@ -81,6 +82,22 @@
 
             return $http(requestOptions);
 
+        }
+
+        /**
+         * Get the overall upgrade status
+         *
+         * @return {Promise}
+         */
+        function getStatus() {
+
+            var requestOptions = {
+                method: 'GET',
+                url: '/api/upgrade',
+                headers: COMMON_API_V2_HEADERS
+            };
+
+            return $http(requestOptions);
         }
     }
 })();

--- a/assets/app/data/crowbar/services/upgrade.factory.spec.js
+++ b/assets/app/data/crowbar/services/upgrade.factory.spec.js
@@ -5,10 +5,12 @@ describe('Upgrade Factory', function () {
         mockedPrepareNodesData = '--mockedNodesRepoChecksData--',
         mockedNodesRepoChecksData = '--mockedNodesRepoChecksData--',
         mockedRepositoriesChecksData = '--mockedRepositoriesChecksData--',
+        mockedStatusData = '--mockedStatusData--',
         preliminaryChecksPromise,
         repositoriesChecksPromise,
         prepareNodesPromise,
-        nodesRepoChecksPromise;
+        nodesRepoChecksPromise,
+        statusPromise;
 
     beforeEach(function () {
         //Setup the module and dependencies to be used.
@@ -148,6 +150,35 @@ describe('Upgrade Factory', function () {
                 repositoriesChecksPromise.then(function (repositoriesChecksResponse) {
                     expect(repositoriesChecksResponse.status).toEqual(200);
                     expect(repositoriesChecksResponse.data).toEqual(mockedRepositoriesChecksData);
+                });
+                $httpBackend.flush();
+            });
+
+        });
+
+        describe('when getStatus method is executed', function () {
+
+            beforeEach(function () {
+
+                $httpBackend.expectGET('/api/upgrade', COMMON_API_V2_HEADERS)
+                    .respond(200, mockedStatusData);
+                statusPromise = upgradeFactory.getStatus();
+            });
+
+            it('returns a promise', function () {
+                expect(statusPromise).toEqual(jasmine.any(Object));
+                expect(statusPromise['then']).toEqual(jasmine.any(Function));
+                expect(statusPromise['catch']).toEqual(jasmine.any(Function));
+                expect(statusPromise['finally']).toEqual(jasmine.any(Function));
+                expect(statusPromise['error']).toEqual(jasmine.any(Function));
+                expect(statusPromise['success']).toEqual(jasmine.any(Function));
+            });
+
+            // getStatus success, partially passing and/or failing are handled in the controller.
+            it('when resolved, it returns the upgrade status response', function () {
+                statusPromise.then(function (response) {
+                    expect(response.status).toEqual(200);
+                    expect(response.data).toEqual(mockedStatusData);
                 });
                 $httpBackend.flush();
             });

--- a/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
@@ -12,12 +12,13 @@
         .controller('UpgradeUpgradeAdministrationServerController', UpgradeUpgradeAdministrationServerController);
 
     UpgradeUpgradeAdministrationServerController.$inject = [
-        '$timeout', 'crowbarFactory', 'ADMIN_UPGRADE_TIMEOUT_INTERVAL', 'upgradeStepsFactory'
+        '$timeout', 'crowbarFactory', 'upgradeFactory', 'ADMIN_UPGRADE_TIMEOUT_INTERVAL', 'upgradeStepsFactory'
     ];
     // @ngInject
     function UpgradeUpgradeAdministrationServerController(
       $timeout,
       crowbarFactory,
+      upgradeFactory,
       ADMIN_UPGRADE_TIMEOUT_INTERVAL,
       upgradeStepsFactory
     ) {
@@ -61,13 +62,13 @@
         }
 
         function checkAdminUpgrade() {
-            crowbarFactory.getUpgradeStatus()
+            upgradeFactory.getStatus()
                 .then(
                     // In case of success
                     function (response) {
                         // map api response to model
-                        vm.adminUpgrade.completed = response.data.upgrade.success;
-                        vm.adminUpgrade.running = response.data.upgrade.upgrading;
+                        vm.adminUpgrade.completed = response.data.steps.admin_upgrade.status === 'passed';
+                        vm.adminUpgrade.running = response.data.steps.admin_upgrade.status === 'running';
                     },
                     // In case of failure
                     function (errorResponse) {

--- a/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.spec.js
@@ -1,42 +1,149 @@
-/*global bard $controller should $httpBackend crowbarFactory assert $q $rootScope */
+/* global bard $controller should $httpBackend upgradeFactory crowbarFactory
+ assert $q $rootScope ADMIN_UPGRADE_TIMEOUT_INTERVAL */
 describe('Upgrade Flow - Upgrade Administration Server Controller', function () {
     var controller,
-        completedUpgradeResponse = {
-            data: {
-                version: '3.0',
-                addons: [],
-                upgrade: {
-                    upgrading: false,
-                    success: true,
-                    failed: false
+        completedUpgradeResponseData = {
+            current_step: 'admin_upgrade',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                    errors: {}
+                },
+                admin_backup: {
+                    status: 'passed',
+                    errors: {}
+                },
+                admin_repo_checks: {
+                    status: 'passed',
+                    errors: {}
+                },
+                admin_upgrade: {
+                    status: 'passed',
+                    errors: {}
+                },
+                database: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_services: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                    errors: {}
+                },
+                finished: {
+                    status: 'pending',
+                    errors: {}
                 }
             }
         },
-        incompleteUpgradeResponse = {
-            data: {
-                version: '3.0',
-                addons: [],
-                upgrade: {
-                    upgrading: true,
-                    success: false,
-                    failed: false
+        incompleteUpgradeResponseData = {
+            current_step: 'admin_upgrade',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                    errors: {}
+                },
+                admin_backup: {
+                    status: 'passed',
+                    errors: {}
+                },
+                admin_repo_checks: {
+                    status: 'passed',
+                    errors: {}
+                },
+                admin_upgrade: {
+                    status: 'running',
+                    errors: {}
+                },
+                database: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_services: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                    errors: {}
+                },
+                finished: {
+                    status: 'pending',
+                    errors: {}
                 }
             }
         },
-        initialResponse = {
-            version: '3.0',
-            addons: [],
-            upgrade: {
-                upgrading: false,
-                success: false,
-                failed: false
+        initialResponseData = {
+            current_step: 'admin_upgrade',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                    errors: {}
+                },
+                admin_backup: {
+                    status: 'passed',
+                    errors: {}
+                },
+                admin_repo_checks: {
+                    status: 'passed',
+                    errors: {}
+                },
+                admin_upgrade: {
+                    status: 'pending',
+                    errors: {}
+                },
+                database: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_services: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                    errors: {}
+                },
+                finished: {
+                    status: 'pending',
+                    errors: {}
+                }
             }
         },
-        errorList = ['1', '2', '3'],
-        // TODO(itxaka): change this to the proper response from the API
-        errorResponse = {
-            data: { errors: errorList }
-        },
+        activeStatusResponse = { data: null },
         mockedTimeout;
 
     beforeEach(function() {
@@ -44,24 +151,22 @@ describe('Upgrade Flow - Upgrade Administration Server Controller', function () 
         bard.appModule('crowbarApp.upgrade');
         bard.inject(
             '$controller', '$q', '$httpBackend', '$rootScope',
-            'crowbarFactory', 'ADMIN_UPGRADE_TIMEOUT_INTERVAL'
+            'crowbarFactory', 'upgradeFactory', 'ADMIN_UPGRADE_TIMEOUT_INTERVAL'
         );
 
         mockedTimeout = jasmine.createSpy('$timeout');
 
+        // reset the active response to the default values
+        activeStatusResponse.data = initialResponseData;
+        bard.mockService(upgradeFactory, {
+            getStatus: $q.when(activeStatusResponse)
+        });
+
         //Create the controller
         controller = $controller('UpgradeUpgradeAdministrationServerController', { '$timeout': mockedTimeout });
 
-        // reset the initialResponse to the default values
-        initialResponse.upgrade = {
-            upgrading: false,
-            success: false,
-            failed: false
-        };
-
         //Mock requests that are expected to be made
         $httpBackend.expectGET('app/features/upgrade/i18n/en.json').respond({});
-        $httpBackend.expectGET('/api/crowbar/upgrade').respond(initialResponse);
         $httpBackend.flush();
     });
 
@@ -73,25 +178,20 @@ describe('Upgrade Flow - Upgrade Administration Server Controller', function () 
     });
 
     describe('on controller creation', function () {
-
         it('should set running to true if the upgrade is running', function () {
-            initialResponse.upgrade.upgrading = true;
+            activeStatusResponse.data = incompleteUpgradeResponseData;
             // recreate the controller so it can pick our modified initialResponse
             controller = $controller('UpgradeUpgradeAdministrationServerController');
-            // expect the call
-            $httpBackend.expectGET('/api/crowbar/upgrade').respond(initialResponse);
-            // resolve all http calls
-            $httpBackend.flush();
+            $rootScope.$digest();
             // initial model should have changed based on the initialization response
             assert.isFalse(controller.adminUpgrade.completed);
             assert.isTrue(controller.adminUpgrade.running);
         });
 
         it('should set completed to true if upgrade is completed', function () {
-            initialResponse.upgrade.success = true;
+            activeStatusResponse.data = completedUpgradeResponseData;
             controller = $controller('UpgradeUpgradeAdministrationServerController');
-            $httpBackend.expectGET('/api/crowbar/upgrade').respond(initialResponse);
-            $httpBackend.flush();
+            $rootScope.$digest();
             assert.isTrue(controller.adminUpgrade.completed);
             assert.isFalse(controller.adminUpgrade.running);
         });
@@ -121,7 +221,7 @@ describe('Upgrade Flow - Upgrade Administration Server Controller', function () 
                     spyOn(controller.adminUpgrade, 'checkAdminUpgrade');
 
                     bard.mockService(crowbarFactory, {
-                        upgrade: $q.when(incompleteUpgradeResponse)
+                        upgrade: $q.when({})
                     });
                     controller.adminUpgrade.beginAdminUpgrade();
                     $rootScope.$digest();
@@ -136,6 +236,93 @@ describe('Upgrade Flow - Upgrade Administration Server Controller', function () 
                 });
             });
 
+
+        });
+
+        describe('checkAdminUpgrade function', function () {
+            it('should be defined', function () {
+                should.exist(controller.adminUpgrade.checkAdminUpgrade);
+                expect(controller.adminUpgrade.checkAdminUpgrade).toEqual(jasmine.any(Function));
+            });
+
+            describe('when got upgrade status from api successfully', function () {
+                describe('when received status is completed', function () {
+                    beforeEach(function () {
+                        activeStatusResponse.data = completedUpgradeResponseData;
+
+                        controller.adminUpgrade.checkAdminUpgrade();
+                        $rootScope.$digest();
+                    });
+
+                    it('should set running attribute of adminUpgrade model to false', function () {
+                        assert.isFalse(controller.adminUpgrade.running);
+                    });
+                    it('should set completed flag to true', function () {
+                        assert.isTrue(controller.adminUpgrade.completed);
+                    });
+                    it('should not schedule another check', function () {
+                        expect(mockedTimeout).not.toHaveBeenCalled();
+                    });
+                });
+
+                describe('when received status is not completed', function () {
+                    beforeEach(function () {
+                        activeStatusResponse.data = incompleteUpgradeResponseData;
+
+                        controller.adminUpgrade.running = true;
+                        controller.adminUpgrade.checkAdminUpgrade();
+                        $rootScope.$digest();
+                    });
+                    it('should keep running flag set to true', function () {
+                        assert.isTrue(controller.adminUpgrade.running);
+                    });
+                    it('should keep completed flag set to false', function () {
+                        assert.isFalse(controller.adminUpgrade.completed);
+                    });
+                    it('should schedule another check', function () {
+                        expect(mockedTimeout).toHaveBeenCalledWith(
+                            controller.adminUpgrade.checkAdminUpgrade, ADMIN_UPGRADE_TIMEOUT_INTERVAL
+                        );
+                    });
+                });
+            });
+        });
+    });
+});
+
+describe('Upgrade Flow - Upgrade Administration Server Controller - errors', function () {
+    var controller,
+        errorList = ['1', '2', '3'],
+        // TODO(itxaka): change this to the proper response from the API
+        errorResponse = {
+            data: { errors: errorList }
+        };
+
+    beforeEach(function() {
+        //Setup the module and dependencies to be used.
+        bard.appModule('crowbarApp.upgrade');
+        bard.inject(
+            '$controller', '$q', '$httpBackend', '$rootScope',
+            'crowbarFactory', 'upgradeFactory', 'ADMIN_UPGRADE_TIMEOUT_INTERVAL'
+        );
+
+        bard.mockService(upgradeFactory, {
+            getStatus: $q.reject(errorResponse)
+        });
+
+        //Create the controller
+        controller = $controller('UpgradeUpgradeAdministrationServerController');
+
+        //Mock requests that are expected to be made
+        $httpBackend.expectGET('app/features/upgrade/i18n/en.json').respond({});
+        $httpBackend.flush();
+    });
+
+    // Verify no unexpected http call has been made
+    bard.verifyNoOutstandingHttpRequests();
+
+    describe('adminUpgrade model', function () {
+        describe('beginAdminUpgrade function', function () {
             describe('when starting upgrade failed', function () {
                 beforeEach(function () {
                     spyOn(controller.adminUpgrade, 'checkAdminUpgrade');
@@ -159,66 +346,12 @@ describe('Upgrade Flow - Upgrade Administration Server Controller', function () 
                     expect(controller.adminUpgrade.errors).toEqual(errorList);
                 });
             });
-
         });
 
         describe('checkAdminUpgrade function', function () {
-            it('should be defined', function () {
-                should.exist(controller.adminUpgrade.checkAdminUpgrade);
-                expect(controller.adminUpgrade.checkAdminUpgrade).toEqual(jasmine.any(Function));
-            });
-
-            describe('when got upgrade status from api successfully', function () {
-                describe('when received status is completed', function () {
-                    beforeEach(function () {
-                        bard.mockService(crowbarFactory, {
-                            getUpgradeStatus: $q.when(completedUpgradeResponse)
-                        });
-                        controller.adminUpgrade.checkAdminUpgrade();
-                        $rootScope.$digest();
-                    });
-
-                    it('should set running attribute of adminUpgrade model to false', function () {
-                        assert.isFalse(controller.adminUpgrade.running);
-                    });
-                    it('should set completed flag to true', function () {
-                        assert.isTrue(controller.adminUpgrade.completed);
-                    });
-                    it('should not schedule another check', function () {
-                        expect(mockedTimeout).not.toHaveBeenCalled();
-                    });
-                });
-
-                describe('when received status is not completed', function () {
-                    beforeEach(function () {
-                        bard.mockService(crowbarFactory, {
-                            getUpgradeStatus: $q.when(incompleteUpgradeResponse)
-                        });
-                        controller.adminUpgrade.running = true;
-                        controller.adminUpgrade.checkAdminUpgrade();
-                        $rootScope.$digest();
-                    });
-                    it('should keep running flag set to true', function () {
-                        assert.isTrue(controller.adminUpgrade.running);
-                    });
-                    it('should keep completed flag set to false', function () {
-                        assert.isFalse(controller.adminUpgrade.completed);
-                    });
-                    it('should schedule another check', function () {
-                        /* eslint-disable no-undef */
-                        expect(mockedTimeout).toHaveBeenCalledWith(
-                            controller.adminUpgrade.checkAdminUpgrade, ADMIN_UPGRADE_TIMEOUT_INTERVAL
-                        );
-                        /* eslint-enable no-undef */
-                    });
-                });
-            });
 
             describe('when got error from api', function () {
                 beforeEach(function () {
-                    bard.mockService(crowbarFactory, {
-                        getUpgradeStatus: $q.reject(errorResponse)
-                    });
                     controller.adminUpgrade.checkAdminUpgrade();
                     $rootScope.$digest();
                 });

--- a/routes/api/upgrade.js
+++ b/routes/api/upgrade.js
@@ -1,0 +1,84 @@
+var express = require('express'),
+    router = express.Router();
+
+var errors = ['001', '002', '003'];
+
+var status_counter = -1,
+    tested_step = 'admin_upgrade',
+    status = {
+        current_step: 'upgrade_prechecks',
+        substep: null,
+        current_node: null,
+        steps: {
+            upgrade_prechecks: {
+                status: 'pending',
+                errors: {}
+            },
+            admin_backup: {
+                status: 'pending',
+                errors: {}
+            },
+            admin_repo_checks: {
+                status: 'pending',
+                errors: {}
+            },
+            admin_upgrade: {
+                status: 'pending',
+                errors: {}
+            },
+            database: {
+                status: 'pending',
+                errors: {}
+            },
+            nodes_repo_checks: {
+                status: 'pending',
+                errors: {}
+            },
+            nodes_services: {
+                status: 'pending',
+                errors: {}
+            },
+            nodes_db_dump: {
+                status: 'pending',
+                errors: {}
+            },
+            nodes_upgrade: {
+                status: 'pending',
+                errors: {}
+            },
+            finished: {
+                status: 'pending',
+                errors: {}
+            }
+        }
+    };
+
+/* GET upgrade status. */
+router.get('/', function(req, res) {
+    status_counter += 1;
+
+    function testedStatus() {
+        switch (status_counter) {
+        case 0:
+            return 'pending';
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+            return 'running';
+        case 5:
+        default:
+            return 'passed';
+        }
+    }
+    if('fail' in req.query && JSON.parse(req.query.fail) === true) {
+        res.status(500).json({'errors': errors});
+    } else {
+        status.current_step = tested_step;
+        status.steps[tested_step].status = testedStatus();
+
+        res.status(200).json(status);
+    }
+});
+
+module.exports = router;


### PR DESCRIPTION
The overall upgrade status API at /api/upgrade gives more details about
the situation in the backend and is implemented also in crowbar-init.
This is important during admin server upgrade as crowbar is shut down
during the upgrade and can't provide status information.

This change switches from /api/crowbar/upgrade to /api/upgrade in the
context of admin server upgrade. The old service for accessing crowbar
upgrade status is not removed.