### PR TITLE
Asynchronous prepare step & status downtime

### DIFF
--- a/assets/app/data/crowbar/services/upgrade-status.factory.js
+++ b/assets/app/data/crowbar/services/upgrade-status.factory.js
@@ -1,0 +1,48 @@
+(function() {
+
+    angular
+        .module('suseData.crowbar')
+        .factory('upgradeStatusFactory', upgradeStatusFactory);
+
+    upgradeStatusFactory.$inject = ['$http', '$timeout', 'upgradeFactory'];
+    /* @ngInject */
+    function upgradeStatusFactory($http, $timeout, upgradeFactory) {
+        var factory = {
+            waitForStepToEnd: waitForStepToEnd,
+        };
+
+        return factory;
+
+        /**
+         * Polls for upgrade status until step `step` is `passed`.
+         *
+         * @param {string} step - Step name as defined in status API response
+         * @param {function} onSuccess - Callback to be executed with last response from status API
+         *     when waiting time finishes successfully
+         * @param {function} onError - Callback to be executed if status API returns error
+         * @param {int} pollingInterval - Interval used to poll the upgrade status
+         * @param {int} [allowedDowntimeLeft=0] - If specified, temporary unavailability of status
+         *     API will not trigger `onError` handler and will not stop polling. The downtime
+         *     allowance is common for whole call so if there are multiple short unavailability
+         *     periods, the total time (sum) is checked.
+         */
+        function waitForStepToEnd(step, onSuccess, onError, pollingInterval) {
+            upgradeFactory.getStatus()
+                .then(
+                    function (response) {
+                        if (response.data.steps[step].status == 'passed') {
+                            onSuccess(response);
+                        } else {
+                            // schedule another check
+                            $timeout(function () {
+                                factory.waitForStepToEnd(step, onSuccess, onError, pollingInterval);
+                            }, pollingInterval);
+                        }
+                    },
+                    function (errorResponse) {
+                        onError(errorResponse);
+                    }
+                );
+        }
+    }
+})();

--- a/assets/app/data/crowbar/services/upgrade-status.factory.spec.js
+++ b/assets/app/data/crowbar/services/upgrade-status.factory.spec.js
@@ -1,0 +1,194 @@
+/*global bard $q $rootScope should expect module upgradeFactory upgradeStatusFactory */
+describe('Upgrade Status Factory', function () {
+    var pollingInterval = 1234,
+        testedStep = 'admin_upgrade',
+        completedUpgradeResponseData = {
+            current_step: 'admin_upgrade',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                    errors: {}
+                },
+                admin_backup: {
+                    status: 'passed',
+                    errors: {}
+                },
+                admin_repo_checks: {
+                    status: 'passed',
+                    errors: {}
+                },
+                admin_upgrade: {
+                    status: 'passed',
+                    errors: {}
+                },
+                database: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_services: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                    errors: {}
+                },
+                finished: {
+                    status: 'pending',
+                    errors: {}
+                }
+            }
+        },
+        completedUpgradeResponse = {
+            data: completedUpgradeResponseData,
+        },
+        incompleteUpgradeResponseData = {
+            current_step: 'admin_upgrade',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                    errors: {}
+                },
+                admin_backup: {
+                    status: 'passed',
+                    errors: {}
+                },
+                admin_repo_checks: {
+                    status: 'passed',
+                    errors: {}
+                },
+                admin_upgrade: {
+                    status: 'running',
+                    errors: {}
+                },
+                database: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_services: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                    errors: {}
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                    errors: {}
+                },
+                finished: {
+                    status: 'pending',
+                    errors: {}
+                }
+            }
+        },
+        incompleteUpgradeResponse = {
+            data: incompleteUpgradeResponseData,
+        },
+        mockedSuccessCallback,
+        mockedErrorCallback,
+        mockedTimeout;
+
+    beforeEach(function () {
+        //Setup the module and dependencies to be used.
+        bard.appModule('suseData.crowbar');
+
+        mockedSuccessCallback = jasmine.createSpy('onSuccess');
+        mockedErrorCallback = jasmine.createSpy('onError');
+
+        // mock $timeout service
+        module(function($provide) {
+            $provide.factory('$timeout', function () {
+                mockedTimeout = jasmine.createSpy('$timeout');
+                return mockedTimeout;
+            });
+        });
+
+        // inject the rest of dependencies using BardJS
+        bard.inject('upgradeStatusFactory', 'upgradeFactory', '$q', '$rootScope');
+    });
+
+    describe('when executed', function () {
+
+        it('returns an object', function () {
+            should.exist(upgradeStatusFactory);
+        });
+
+        describe('waitForStepToEnd function', function () {
+            it('should be defined', function () {
+                should.exist(upgradeStatusFactory.waitForStepToEnd);
+                expect(upgradeStatusFactory.waitForStepToEnd).toEqual(jasmine.any(Function));
+            });
+
+            describe('when got upgrade status from api successfully', function () {
+                describe('when received status is completed', function () {
+                    beforeEach(function () {
+                        bard.mockService(upgradeFactory, {
+                            getStatus: $q.when(completedUpgradeResponse)
+                        });
+
+                        upgradeStatusFactory.waitForStepToEnd(
+                            testedStep, mockedSuccessCallback, mockedErrorCallback, pollingInterval
+                        );
+
+                        $rootScope.$digest();
+                    });
+
+                    it('should call success callback', function () {
+                        expect(mockedSuccessCallback).toHaveBeenCalled();
+                    });
+                    it('should not call error callback', function () {
+                        expect(mockedErrorCallback).not.toHaveBeenCalled();
+                    });
+                    it('should not schedule another check', function () {
+                        expect(mockedTimeout).not.toHaveBeenCalled();
+                    });
+                });
+
+                describe('when received status is not completed', function () {
+                    beforeEach(function () {
+                        bard.mockService(upgradeFactory, {
+                            getStatus: $q.when(incompleteUpgradeResponse)
+                        });
+
+                        upgradeStatusFactory.waitForStepToEnd(
+                            testedStep, mockedSuccessCallback, mockedErrorCallback, pollingInterval
+                        );
+
+                        $rootScope.$digest();
+                    });
+                    it('should not call success callback', function () {
+                        expect(mockedSuccessCallback).not.toHaveBeenCalled();
+                    });
+                    it('should not call error callback', function () {
+                        expect(mockedErrorCallback).not.toHaveBeenCalled();
+                    });
+                    it('should schedule another check', function () {
+                        expect(mockedTimeout).toHaveBeenCalledWith(
+                            jasmine.any(Function), pollingInterval
+                        );
+                    });
+                });
+            });
+        });
+
+    });
+
+});

--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
@@ -18,7 +18,8 @@
         'upgradeStatusFactory',
         'crowbarFactory',
         'ADDONS_PRECHECK_MAP',
-        'PREPARE_TIMEOUT_INTERVAL'
+        'PREPARE_TIMEOUT_INTERVAL',
+        'UPGRADE_STEPS',
     ];
     // @ngInject
     function UpgradeLandingController(
@@ -28,7 +29,8 @@
         upgradeStatusFactory,
         crowbarFactory,
         ADDONS_PRECHECK_MAP,
-        PREPARE_TIMEOUT_INTERVAL
+        PREPARE_TIMEOUT_INTERVAL,
+        UPGRADE_STEPS
     ) {
         var vm = this,
             optionalPrechecks = {
@@ -99,7 +101,7 @@
                 function (/* response */) {
                     vm.prepare.running = true;
                     upgradeStatusFactory.waitForStepToEnd(
-                        'upgrade_prepare',
+                        UPGRADE_STEPS.upgrade_prepare,
                         function (/*response*/) {
                             vm.prepare.running = false;
                             $state.go('upgrade.backup');

--- a/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
@@ -12,14 +12,18 @@
         .controller('UpgradeUpgradeAdministrationServerController', UpgradeUpgradeAdministrationServerController);
 
     UpgradeUpgradeAdministrationServerController.$inject = [
-        '$timeout', 'crowbarFactory', 'upgradeFactory', 'ADMIN_UPGRADE_TIMEOUT_INTERVAL', 'upgradeStepsFactory'
+        '$timeout', 'crowbarFactory', 'upgradeStatusFactory',
+        'ADMIN_UPGRADE_TIMEOUT_INTERVAL',
+        'upgradeFactory', 'upgradeStepsFactory'
     ];
     // @ngInject
     function UpgradeUpgradeAdministrationServerController(
       $timeout,
       crowbarFactory,
-      upgradeFactory,
+      upgradeStatusFactory,
       ADMIN_UPGRADE_TIMEOUT_INTERVAL,
+      ADMIN_UPGRADE_ALLOWED_DOWNTIME,
+      upgradeFactory,
       upgradeStepsFactory
     ) {
         var vm = this;
@@ -28,8 +32,6 @@
             running: false,
             spinnerVisible: false,
             beginAdminUpgrade: beginAdminUpgrade,
-            // note: this is exposed in vm only to simplify testing
-            checkAdminUpgrade: checkAdminUpgrade
         };
 
         activate();
@@ -39,7 +41,18 @@
             // the button status and the update check running
             // TODO(itxaka): Not tested yet, tests should be done as part of card:
             // https://trello.com/c/5fXGm1a7/45-2-27-restore-last-step
-            checkAdminUpgrade();
+            upgradeFactory.getStatus()
+                .then(
+                    function (response) {
+                        vm.adminUpgrade.running = response.data.steps.admin_upgrade.status == 'running';
+                        vm.adminUpgrade.completed = response.data.steps.admin_upgrade.status == 'passed';
+                        if (vm.adminUpgrade.completed) {
+                            upgradeStepsFactory.setCurrentStepCompleted();
+                        }
+                    },
+                    function (/*errorResponse*/) {
+                    }
+                );
         }
 
         function beginAdminUpgrade() {
@@ -49,8 +62,22 @@
                 .then(
                     // In case of success
                     function (/*response*/) {
-                        // start running checkAdminUpgrade at an interval
-                        vm.adminUpgrade.checkAdminUpgrade();
+                        vm.adminUpgrade.running = true;
+                        upgradeStatusFactory.waitForStepToEnd(
+                            'admin_upgrade',
+                            function (/*response*/) {
+                                vm.adminUpgrade.running = false;
+                                vm.adminUpgrade.completed = true;
+                                upgradeStepsFactory.setCurrentStepCompleted();
+                            },
+                            function (errorResponse) {
+                                vm.adminUpgrade.running = false;
+                                // TODO(itxaka): Use the proper error key from the response when this is done
+                                // https://trello.com/c/chzg85j4/142-3-s49p7-error-reporting-on-crowbar-level
+                                vm.adminUpgrade.errors = errorResponse.data.errors;
+                            },
+                            ADMIN_UPGRADE_TIMEOUT_INTERVAL
+                        );
                     },
                     // In case of failure
                     function (errorResponse) {
@@ -61,34 +88,5 @@
                 );
         }
 
-        function checkAdminUpgrade() {
-            upgradeFactory.getStatus()
-                .then(
-                    // In case of success
-                    function (response) {
-                        // map api response to model
-                        vm.adminUpgrade.completed = response.data.steps.admin_upgrade.status === 'passed';
-                        vm.adminUpgrade.running = response.data.steps.admin_upgrade.status === 'running';
-                    },
-                    // In case of failure
-                    function (errorResponse) {
-                        // Expose the error list to adminUpgrade object
-                        // TODO(itxaka): Use the proper error key from the response when this is done
-                        // https://trello.com/c/chzg85j4/142-3-s49p7-error-reporting-on-crowbar-level
-                        vm.adminUpgrade.errors = errorResponse.data.errors;
-                    }
-                ).finally(
-                    function () {
-                        // schedule another check if not completed yet
-                        if (!vm.adminUpgrade.completed && vm.adminUpgrade.running) {
-                            $timeout(vm.adminUpgrade.checkAdminUpgrade, ADMIN_UPGRADE_TIMEOUT_INTERVAL);
-                        }
-                        // If the upgrade was completed set the step to completed
-                        if (vm.adminUpgrade.completed) {
-                            upgradeStepsFactory.setCurrentStepCompleted();
-                        }
-                    }
-                );
-        }
     }
 })();

--- a/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
@@ -48,6 +48,8 @@
                         vm.adminUpgrade.completed = response.data.steps.admin_upgrade.status == 'passed';
                         if (vm.adminUpgrade.completed) {
                             upgradeStepsFactory.setCurrentStepCompleted();
+                        } else if (vm.adminUpgrade.running) {
+                            waitForUpgradeToEnd();
                         }
                     },
                     function (/*errorResponse*/) {
@@ -63,22 +65,7 @@
                     // In case of success
                     function (/*response*/) {
                         vm.adminUpgrade.running = true;
-                        upgradeStatusFactory.waitForStepToEnd(
-                            'admin_upgrade',
-                            function (/*response*/) {
-                                vm.adminUpgrade.running = false;
-                                vm.adminUpgrade.completed = true;
-                                upgradeStepsFactory.setCurrentStepCompleted();
-                            },
-                            function (errorResponse) {
-                                vm.adminUpgrade.running = false;
-                                // TODO(itxaka): Use the proper error key from the response when this is done
-                                // https://trello.com/c/chzg85j4/142-3-s49p7-error-reporting-on-crowbar-level
-                                vm.adminUpgrade.errors = errorResponse.data.errors;
-                            },
-                            ADMIN_UPGRADE_TIMEOUT_INTERVAL,
-                            ADMIN_UPGRADE_ALLOWED_DOWNTIME
-                        );
+                        waitForUpgradeToEnd();
                     },
                     // In case of failure
                     function (errorResponse) {
@@ -87,6 +74,25 @@
                         vm.adminUpgrade.errors = errorResponse.data.errors;
                     }
                 );
+        }
+
+        function waitForUpgradeToEnd() {
+            upgradeStatusFactory.waitForStepToEnd(
+                'admin_upgrade',
+                function (/*response*/) {
+                    vm.adminUpgrade.running = false;
+                    vm.adminUpgrade.completed = true;
+                    upgradeStepsFactory.setCurrentStepCompleted();
+                },
+                function (errorResponse) {
+                    vm.adminUpgrade.running = false;
+                    // TODO(itxaka): Use the proper error key from the response when this is done
+                    // https://trello.com/c/chzg85j4/142-3-s49p7-error-reporting-on-crowbar-level
+                    vm.adminUpgrade.errors = errorResponse.data.errors;
+                },
+                ADMIN_UPGRADE_TIMEOUT_INTERVAL,
+                ADMIN_UPGRADE_ALLOWED_DOWNTIME
+            );
         }
 
     }

--- a/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
@@ -13,7 +13,7 @@
 
     UpgradeUpgradeAdministrationServerController.$inject = [
         '$timeout', 'crowbarFactory', 'upgradeStatusFactory',
-        'ADMIN_UPGRADE_TIMEOUT_INTERVAL',
+        'ADMIN_UPGRADE_TIMEOUT_INTERVAL', 'ADMIN_UPGRADE_ALLOWED_DOWNTIME',
         'upgradeFactory', 'upgradeStepsFactory'
     ];
     // @ngInject
@@ -76,7 +76,8 @@
                                 // https://trello.com/c/chzg85j4/142-3-s49p7-error-reporting-on-crowbar-level
                                 vm.adminUpgrade.errors = errorResponse.data.errors;
                             },
-                            ADMIN_UPGRADE_TIMEOUT_INTERVAL
+                            ADMIN_UPGRADE_TIMEOUT_INTERVAL,
+                            ADMIN_UPGRADE_ALLOWED_DOWNTIME
                         );
                     },
                     // In case of failure

--- a/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
@@ -14,7 +14,7 @@
     UpgradeUpgradeAdministrationServerController.$inject = [
         '$timeout', 'crowbarFactory', 'upgradeStatusFactory',
         'ADMIN_UPGRADE_TIMEOUT_INTERVAL', 'ADMIN_UPGRADE_ALLOWED_DOWNTIME',
-        'upgradeFactory', 'upgradeStepsFactory'
+        'UPGRADE_STEPS', 'STEP_STATES', 'upgradeFactory', 'upgradeStepsFactory'
     ];
     // @ngInject
     function UpgradeUpgradeAdministrationServerController(
@@ -23,6 +23,8 @@
       upgradeStatusFactory,
       ADMIN_UPGRADE_TIMEOUT_INTERVAL,
       ADMIN_UPGRADE_ALLOWED_DOWNTIME,
+      UPGRADE_STEPS,
+      STEP_STATES,
       upgradeFactory,
       upgradeStepsFactory
     ) {
@@ -44,8 +46,8 @@
             upgradeFactory.getStatus()
                 .then(
                     function (response) {
-                        vm.adminUpgrade.running = response.data.steps.admin_upgrade.status == 'running';
-                        vm.adminUpgrade.completed = response.data.steps.admin_upgrade.status == 'passed';
+                        vm.adminUpgrade.running = response.data.steps.admin_upgrade.status == STEP_STATES.running;
+                        vm.adminUpgrade.completed = response.data.steps.admin_upgrade.status == STEP_STATES.passed;
                         if (vm.adminUpgrade.completed) {
                             upgradeStepsFactory.setCurrentStepCompleted();
                         } else if (vm.adminUpgrade.running) {
@@ -78,7 +80,7 @@
 
         function waitForUpgradeToEnd() {
             upgradeStatusFactory.waitForStepToEnd(
-                'admin_upgrade',
+                UPGRADE_STEPS.admin_upgrade,
                 function (/*response*/) {
                     vm.adminUpgrade.running = false;
                     vm.adminUpgrade.completed = true;

--- a/assets/app/features/upgrade/templates/landing-page.jade
+++ b/assets/app/features/upgrade/templates/landing-page.jade
@@ -29,7 +29,11 @@
         .col-sm-10.col-sm-offset-1.note-message.text-center
             strong(translate='') upgrade.steps.landing.note
 
-    button.btn.btn-success.center-block(translate='',
-        ng-disabled="!upgradeLandingVm.prechecks.completed || !upgradeLandingVm.prechecks.valid",
+    button.btn.btn-success.center-block(
+        ng-disabled="!upgradeLandingVm.prechecks.completed || !upgradeLandingVm.prechecks.valid || upgradeLandingVm.prepare.running",
+        ng-class="{'spinner-visible': upgradeLandingVm.prepare.spinnerVisible, active: upgradeLandingVm.prepare.running}",
         ng-click="upgradeLandingVm.beginUpgrade()"
-    ) upgrade.steps.landing.form.button
+    )
+        suse-lazy-spinner(delay="2000", active="upgradeLandingVm.prepare.running",
+            visible="upgradeLandingVm.prepare.spinnerVisible")
+        span(translate='') upgrade.steps.landing.form.button

--- a/assets/app/features/upgrade/upgrade.constants.js
+++ b/assets/app/features/upgrade/upgrade.constants.js
@@ -14,5 +14,24 @@
         })
         .constant('PREPARE_TIMEOUT_INTERVAL', 1000)
         .constant('ADMIN_UPGRADE_ALLOWED_DOWNTIME', 30 * 60 * 1000)
-        .constant('ADMIN_UPGRADE_TIMEOUT_INTERVAL', 5000);
+        .constant('ADMIN_UPGRADE_TIMEOUT_INTERVAL', 5000)
+        .constant('UPGRADE_STEPS', {
+            upgrade_prechecks: 'upgrade_prechecks',
+            upgrade_prepare: 'upgrade_prepare',
+            admin_backup: 'admin_backup',
+            admin_repo_checks: 'admin_repo_checks',
+            admin_upgrade: 'admin_upgrade',
+            database: 'database',
+            nodes_repo_checks: 'nodes_repo_checks',
+            nodes_services: 'nodes_services',
+            nodes_db_dump: 'nodes_db_dump',
+            nodes_upgrade: 'nodes_upgrade',
+            finished: 'finished',
+        })
+        .constant('STEP_STATES', {
+            pending: 'pending',
+            running: 'running',
+            passed: 'passed',
+            failed: 'failed',
+        });
 })();

--- a/assets/app/features/upgrade/upgrade.constants.js
+++ b/assets/app/features/upgrade/upgrade.constants.js
@@ -12,5 +12,6 @@
             'ha': ['clusters_healthy'],
             'ceph': ['ceph_healthy']
         })
+        .constant('PREPARE_TIMEOUT_INTERVAL', 1000)
         .constant('ADMIN_UPGRADE_TIMEOUT_INTERVAL', 1000);
 })();

--- a/assets/app/features/upgrade/upgrade.constants.js
+++ b/assets/app/features/upgrade/upgrade.constants.js
@@ -13,5 +13,6 @@
             'ceph': ['ceph_healthy']
         })
         .constant('PREPARE_TIMEOUT_INTERVAL', 1000)
-        .constant('ADMIN_UPGRADE_TIMEOUT_INTERVAL', 1000);
+        .constant('ADMIN_UPGRADE_ALLOWED_DOWNTIME', 30 * 60 * 1000)
+        .constant('ADMIN_UPGRADE_TIMEOUT_INTERVAL', 5000);
 })();

--- a/assets/index.jade
+++ b/assets/index.jade
@@ -29,6 +29,7 @@ html(ng-app='crowbarApp')
     script(src='app/data/crowbar/services/crowbar.factory.js')
     script(src='app/data/crowbar/services/crowbar-utils.factory.js')
     script(src='app/data/crowbar/services/upgrade.factory.js')
+    script(src='app/data/crowbar/services/upgrade-status.factory.js')
     script(src='app/data/crowbar/services/openstack.factory.js')
 
     // Crowbar Widgets


### PR DESCRIPTION
The "prepare" call was changed to asynchronous in the backend (i.e. step is performed in the background).
The UI was adjusted to poll for step status before switching to next step.

This PR includes some refactoring for the previous implementation of polling to make it re-usable and optimize tests.

In addition separate commit introduces option to specify allowed downtime for the status service to cover cases where backend which provides status information becomes temporarily unavailable.