### PR TITLE
upgrade: Landing page refresh handling

### DIFF
--- a/assets/app/data/crowbar/services/upgrade-status.factory.js
+++ b/assets/app/data/crowbar/services/upgrade-status.factory.js
@@ -16,6 +16,7 @@
 
         /**
          * Fetch status info from backend and update flags in passed object
+         *
          * @param {string} step - name of step to be checked
          * @param {Object} flagsObject - object with `running` and `completed` fields to be updated
          * @param {function} onRunning - Callback to be executed if current status is running

--- a/assets/app/data/crowbar/services/upgrade-status.factory.spec.js
+++ b/assets/app/data/crowbar/services/upgrade-status.factory.spec.js
@@ -161,11 +161,11 @@ describe('Upgrade Status Factory', function () {
                 });
 
                 it('should call completed callback', function () {
-                    expect(mockedCompletedCallback).toHaveBeenCalled();
+                    expect(mockedCompletedCallback).toHaveBeenCalledTimes(1);
                 });
 
                 it('should not call running callback', function () {
-                    expect(mockedRunningCallback).not.toHaveBeenCalled();
+                    expect(mockedRunningCallback).not.toHaveBeenCalledTimes(1);
                 });
 
                 it('should set completed flag to true', function () {

--- a/assets/app/data/crowbar/services/upgrade-status.factory.spec.js
+++ b/assets/app/data/crowbar/services/upgrade-status.factory.spec.js
@@ -1,4 +1,4 @@
-/*global bard $q $rootScope should expect module upgradeFactory upgradeStatusFactory */
+/*global bard assert $q $rootScope should expect module upgradeFactory upgradeStatusFactory */
 describe('Upgrade Status Factory', function () {
     var pollingInterval = 1234,
         testedStep = 'admin_upgrade',
@@ -102,8 +102,11 @@ describe('Upgrade Status Factory', function () {
         incompleteUpgradeResponse = {
             data: incompleteUpgradeResponseData
         },
+        flagsObject,
         mockedSuccessCallback,
         mockedErrorCallback,
+        mockedRunningCallback,
+        mockedCompletedCallback,
         mockedTimeout,
         errorResponse = {
             error: 'some error'
@@ -115,6 +118,8 @@ describe('Upgrade Status Factory', function () {
 
         mockedSuccessCallback = jasmine.createSpy('onSuccess');
         mockedErrorCallback = jasmine.createSpy('onError');
+        mockedCompletedCallback = jasmine.createSpy('onCompleted');
+        mockedRunningCallback = jasmine.createSpy('onRunning');
 
         // mock $timeout service
         module(function($provide) {
@@ -132,6 +137,77 @@ describe('Upgrade Status Factory', function () {
 
         it('returns an object', function () {
             should.exist(upgradeStatusFactory);
+        });
+
+        describe('syncStatusFlags function', function () {
+            it('should be defined', function () {
+                should.exist(upgradeStatusFactory.syncStatusFlags);
+                expect(upgradeStatusFactory.syncStatusFlags).toEqual(jasmine.any(Function));
+            });
+
+            describe('when received status is completed', function () {
+                beforeEach(function () {
+                    bard.mockService(upgradeFactory, {
+                        getStatus: $q.when(completedUpgradeResponse)
+                    });
+
+                    flagsObject = { running: true, completed: false };
+
+                    upgradeStatusFactory.syncStatusFlags(
+                        testedStep, flagsObject, mockedRunningCallback, mockedCompletedCallback
+                    );
+
+                    $rootScope.$digest();
+                });
+
+                it('should call completed callback', function () {
+                    expect(mockedCompletedCallback).toHaveBeenCalled();
+                });
+
+                it('should not call running callback', function () {
+                    expect(mockedRunningCallback).not.toHaveBeenCalled();
+                });
+
+                it('should set completed flag to true', function () {
+                    assert.isTrue(flagsObject.completed);
+                });
+
+                it('should set running flag to false', function () {
+                    assert.isFalse(flagsObject.running);
+                });
+            });
+
+            describe('when received status is running', function () {
+                beforeEach(function () {
+                    bard.mockService(upgradeFactory, {
+                        getStatus: $q.when(incompleteUpgradeResponse)
+                    });
+
+                    flagsObject = { running: false, completed: true };
+
+                    upgradeStatusFactory.syncStatusFlags(
+                        testedStep, flagsObject, mockedRunningCallback, mockedCompletedCallback
+                    );
+
+                    $rootScope.$digest();
+                });
+
+                it('should not call completed callback', function () {
+                    expect(mockedCompletedCallback).not.toHaveBeenCalled();
+                });
+
+                it('should call running callback', function () {
+                    expect(mockedRunningCallback).toHaveBeenCalled();
+                });
+
+                it('should set completed flag to false', function () {
+                    assert.isFalse(flagsObject.completed);
+                });
+
+                it('should set running flag to true', function () {
+                    assert.isTrue(flagsObject.running);
+                });
+            });
         });
 
         describe('waitForStepToEnd function', function () {

--- a/assets/app/data/crowbar/services/upgrade-status.factory.spec.js
+++ b/assets/app/data/crowbar/services/upgrade-status.factory.spec.js
@@ -3,7 +3,7 @@ describe('Upgrade Status Factory', function () {
     var pollingInterval = 1234,
         testedStep = 'admin_upgrade',
         completedUpgradeResponseData = {
-            current_step: 'admin_upgrade',
+            current_step: 'database',
             substep: null,
             current_node: null,
             steps: {
@@ -165,7 +165,7 @@ describe('Upgrade Status Factory', function () {
                 });
 
                 it('should not call running callback', function () {
-                    expect(mockedRunningCallback).not.toHaveBeenCalledTimes(1);
+                    expect(mockedRunningCallback).not.toHaveBeenCalled();
                 });
 
                 it('should set completed flag to true', function () {
@@ -197,7 +197,7 @@ describe('Upgrade Status Factory', function () {
                 });
 
                 it('should call running callback', function () {
-                    expect(mockedRunningCallback).toHaveBeenCalled();
+                    expect(mockedRunningCallback).toHaveBeenCalledTimes(1);
                 });
 
                 it('should set completed flag to false', function () {

--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
@@ -20,7 +20,6 @@
         'ADDONS_PRECHECK_MAP',
         'PREPARE_TIMEOUT_INTERVAL',
         'UPGRADE_STEPS',
-        'STEP_STATES'
     ];
     // @ngInject
     function UpgradeLandingController(
@@ -31,8 +30,7 @@
         crowbarFactory,
         ADDONS_PRECHECK_MAP,
         PREPARE_TIMEOUT_INTERVAL,
-        UPGRADE_STEPS,
-        STEP_STATES
+        UPGRADE_STEPS
     ) {
         var vm = this,
             optionalPrechecks = {
@@ -89,23 +87,9 @@
                 });
             });
 
-            // adjust UI state to backend status
-            upgradeFactory.getStatus()
-                .then(
-                    function (response) {
-                        // skz: This part is disabled on purpose. There's no easy way to restore complete checks state
-                        // without running the checks again so it's better to leave this to the user.
-                        //vm.prechecks.running = response.data.steps.upgrade_prechecks.status === STEP_STATES.running;
-                        //vm.prechecks.completed = response.data.steps.upgrade_prechecks.status === STEP_STATES.passed;
-
-                        vm.prepare.running = response.data.steps.upgrade_prepare.status === STEP_STATES.running;
-                        vm.prepare.completed = response.data.steps.upgrade_prepare.status === STEP_STATES.passed;
-
-                        if (vm.prepare.running) {
-                            waitForPrepareToEnd();
-                        }
-                    }
-                );
+            // skz: There is no syncing of 'prechecks' part as there's no easy way to restore complete checks state
+            // without running the checks again so it's better to leave this to the user.
+            upgradeStatusFactory.syncStatusFlags(UPGRADE_STEPS.upgrade_prepare, vm.prepare, waitForPrepareToEnd);
         }
 
         /**

--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
@@ -129,6 +129,9 @@
             );
         }
 
+        /**
+         * Start polling for status and wait until prepare step is finished
+         */
         function waitForPrepareToEnd() {
             upgradeStatusFactory.waitForStepToEnd(
                 UPGRADE_STEPS.upgrade_prepare,

--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
@@ -4,7 +4,7 @@
 describe('Upgrade Landing Controller', function() {
     var controller,
         completedUpgradeResponseData = {
-            current_step: 'upgrade_prepare',
+            current_step: 'admin_backup',
             substep: null,
             current_node: null,
             steps: {

--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
@@ -1,6 +1,6 @@
 /* jshint -W117, -W030 */
 /*global bard $controller $httpBackend should assert upgradeFactory upgradeStatusFactory
-  crowbarFactory $q $rootScope module $state sinon */
+  crowbarFactory $q $rootScope module $state */
 describe('Upgrade Landing Controller', function() {
     var controller,
         completedUpgradeResponseData = {
@@ -192,7 +192,7 @@ describe('Upgrade Landing Controller', function() {
         });
 
         bard.mockService(upgradeFactory, {
-            getStatus: $q.when(initialStatusResponse)
+            getStatus: $q.when(initialStatusResponse),
         });
 
         spyOn(upgradeStatusFactory, 'waitForStepToEnd');
@@ -228,8 +228,7 @@ describe('Upgrade Landing Controller', function() {
     describe('when created while prepare is running', function() {
         beforeEach(function() {
             // local change in mocked service
-            upgradeFactory.getStatus =
-                sinon.spy(function () { return $q.when(incompleteUpgradeResponse); });
+            spyOn(upgradeFactory, 'getStatus').and.returnValue($q.when(incompleteUpgradeResponse));
 
             controller = $controller('UpgradeLandingController');
 
@@ -252,8 +251,7 @@ describe('Upgrade Landing Controller', function() {
     describe('when created after prepare is finished', function() {
         beforeEach(function() {
             // local change in mocked service
-            upgradeFactory.getStatus =
-                sinon.spy(function () { return $q.when(completedUpgradeResponse); });
+            spyOn(upgradeFactory, 'getStatus').and.returnValue($q.when(completedUpgradeResponse));
 
             controller = $controller('UpgradeLandingController');
 
@@ -325,8 +323,7 @@ describe('Upgrade Landing Controller', function() {
         describe('with no addons installed', function () {
             beforeEach(function () {
                 // local change in mocked service
-                crowbarFactory.getEntity =
-                    sinon.spy(function () { return $q.when(entityResponseWithoutAddons); });
+                spyOn(crowbarFactory, 'getEntity').and.returnValue($q.when(entityResponseWithoutAddons));
 
                 controller = $controller('UpgradeLandingController');
             });
@@ -349,8 +346,7 @@ describe('Upgrade Landing Controller', function() {
             describe('when checks pass successfully', function () {
                 beforeEach(function () {
                     // local change in mocked service
-                    upgradeFactory.getPreliminaryChecks =
-                        sinon.spy(function () { return $q.when(passingChecksResponse); });
+                    spyOn(upgradeFactory, 'getPreliminaryChecks').and.returnValue($q.when(passingChecksResponse));
 
                     controller.prechecks.runPrechecks();
                     $rootScope.$digest();
@@ -375,8 +371,7 @@ describe('Upgrade Landing Controller', function() {
             describe('when checks fails', function () {
                 beforeEach(function () {
                     // local change in mocked service
-                    upgradeFactory.getPreliminaryChecks =
-                        sinon.spy(function () { return $q.when(failingChecksResponse); });
+                    spyOn(upgradeFactory, 'getPreliminaryChecks').and.returnValue($q.when(failingChecksResponse));
 
                     controller.prechecks.runPrechecks();
                     $rootScope.$digest();
@@ -401,8 +396,8 @@ describe('Upgrade Landing Controller', function() {
             describe('when checks partially fail', function () {
                 beforeEach(function () {
                     // local change in mocked service
-                    upgradeFactory.getPreliminaryChecks =
-                        sinon.spy(function () { return $q.when(partiallyFailingChecksResponse); });
+                    spyOn(upgradeFactory, 'getPreliminaryChecks').and
+                        .returnValue($q.when(partiallyFailingChecksResponse));
 
                     controller.prechecks.runPrechecks();
                     $rootScope.$digest();
@@ -427,8 +422,7 @@ describe('Upgrade Landing Controller', function() {
             describe('when service call fails', function () {
                 beforeEach(function () {
                     // local change in mocked service
-                    upgradeFactory.getPreliminaryChecks =
-                        sinon.spy(function () { return $q.reject(failingResponse); });
+                    spyOn(upgradeFactory, 'getPreliminaryChecks').and.returnValue($q.reject(failingResponse));
 
                     controller.prechecks.runPrechecks();
                     $rootScope.$digest();
@@ -561,8 +555,7 @@ describe('Upgrade Landing Controller - States', function () {
     describe('when node prepare start fails', function () {
         beforeEach(function () {
             // local change in mocked service
-            upgradeFactory.prepareNodes =
-                sinon.spy(function () { return $q.reject(errorResponse); });
+            spyOn(upgradeFactory, 'prepareNodes').and.returnValue($q.reject(errorResponse));
 
             spyOn(upgradeStatusFactory, 'waitForStepToEnd');
 

--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
@@ -1,8 +1,137 @@
 /* jshint -W117, -W030 */
 /*global bard $controller $httpBackend should assert upgradeFactory upgradeStatusFactory
-  crowbarFactory $q $rootScope module $state */
+  crowbarFactory $q $rootScope module $state sinon */
 describe('Upgrade Landing Controller', function() {
     var controller,
+        completedUpgradeResponseData = {
+            current_step: 'upgrade_prepare',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                },
+                upgrade_prepare: {
+                    status: 'passed',
+                },
+                admin_backup: {
+                    status: 'pending',
+                },
+                admin_repo_checks: {
+                    status: 'pending',
+                },
+                admin_upgrade: {
+                    status: 'pending',
+                },
+                database: {
+                    status: 'pending',
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                },
+                nodes_services: {
+                    status: 'pending',
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                },
+                finished: {
+                    status: 'pending',
+                }
+            }
+        },
+        completedUpgradeResponse = {
+            data: completedUpgradeResponseData,
+        },
+        incompleteUpgradeResponseData = {
+            current_step: 'upgrade_prepare',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                },
+                upgrade_prepare: {
+                    status: 'running',
+                },
+                admin_backup: {
+                    status: 'pending',
+                },
+                admin_repo_checks: {
+                    status: 'pending',
+                },
+                admin_upgrade: {
+                    status: 'pending',
+                },
+                database: {
+                    status: 'pending',
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                },
+                nodes_services: {
+                    status: 'pending',
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                },
+                finished: {
+                    status: 'pending',
+                }
+            }
+        },
+        incompleteUpgradeResponse = {
+            data: incompleteUpgradeResponseData,
+        },
+        initialResponseData = {
+            current_step: 'upgrade_prechecks',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'pending',
+                },
+                upgrade_prepare: {
+                    status: 'pending',
+                },
+                admin_backup: {
+                    status: 'pending',
+                },
+                admin_repo_checks: {
+                    status: 'pending',
+                },
+                admin_upgrade: {
+                    status: 'pending',
+                },
+                database: {
+                    status: 'pending',
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                },
+                nodes_services: {
+                    status: 'pending',
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                },
+                finished: {
+                    status: 'pending',
+                }
+            }
+        },
+        initialStatusResponse = {
+            data: initialResponseData,
+        },
         passingChecks = {
             maintenance_updates_installed: { required: true, passed: true },
             network_checks: { required: true, passed: true },
@@ -50,21 +179,24 @@ describe('Upgrade Landing Controller', function() {
             data: {
                 addons: []
             }
-        },
-        activeEntityResponse;
+        };
 
     beforeEach(function() {
         //Setup the module and dependencies to be used.
         bard.appModule('crowbarApp.upgrade');
-        bard.inject('$controller', '$rootScope', 'upgradeFactory', 'crowbarFactory', '$q', '$httpBackend');
+        bard.inject('$controller', '$rootScope', 'upgradeFactory',
+            'crowbarFactory', '$q', '$httpBackend', 'upgradeStatusFactory');
 
-        // mock crowbarEntity with different response using an additional variable
-        activeEntityResponse = entityResponseWithAddons;
         bard.mockService(crowbarFactory, {
-            getEntity: $q.when(activeEntityResponse)
+            getEntity: $q.when(entityResponseWithAddons)
         });
 
-        //Create the controller
+        bard.mockService(upgradeFactory, {
+            getStatus: $q.when(initialStatusResponse)
+        });
+
+        spyOn(upgradeStatusFactory, 'waitForStepToEnd');
+
         controller = $controller('UpgradeLandingController');
 
         //Mock requests that are expected to be made
@@ -78,6 +210,69 @@ describe('Upgrade Landing Controller', function() {
     it('should exist', function() {
         should.exist(controller);
     });
+
+    describe('when created while prepare is not running', function() {
+        it('should not start polling for status', function() {
+            expect(upgradeStatusFactory.waitForStepToEnd).not.toHaveBeenCalled();
+        });
+
+        it('prepare should not be running', function() {
+            assert.isFalse(controller.prepare.running);
+        });
+
+        it('prepare should not be completed', function() {
+            assert.isFalse(controller.prepare.completed);
+        });
+    });
+
+    describe('when created while prepare is running', function() {
+        beforeEach(function() {
+            // local change in mocked service
+            upgradeFactory.getStatus =
+                sinon.spy(function () { return $q.when(incompleteUpgradeResponse); });
+
+            controller = $controller('UpgradeLandingController');
+
+            $rootScope.$digest();
+        });
+
+        it('should start polling for status', function() {
+            expect(upgradeStatusFactory.waitForStepToEnd).toHaveBeenCalled();
+        });
+
+        it('prepare should be running', function() {
+            assert.isTrue(controller.prepare.running);
+        });
+
+        it('prepare should not be completed', function() {
+            assert.isFalse(controller.prepare.completed);
+        });
+    });
+
+    describe('when created while prepare is finished', function() {
+        beforeEach(function() {
+            // local change in mocked service
+            upgradeFactory.getStatus =
+                sinon.spy(function () { return $q.when(completedUpgradeResponse); });
+
+            controller = $controller('UpgradeLandingController');
+
+            $rootScope.$digest();
+        });
+
+        it('should not start polling for status', function() {
+            expect(upgradeStatusFactory.waitForStepToEnd).not.toHaveBeenCalled();
+        });
+
+        it('prepare should not be running', function() {
+            assert.isFalse(controller.prepare.running);
+        });
+
+        it('prepare should be completed', function() {
+            assert.isTrue(controller.prepare.completed);
+        });
+    });
+
 
     describe('Begin Upgrade', function() {
         it('should have a beginUpgrade function defined', function() {
@@ -129,7 +324,10 @@ describe('Upgrade Landing Controller', function() {
 
         describe('with no addons installed', function () {
             beforeEach(function () {
-                activeEntityResponse = entityResponseWithoutAddons;
+                // local change in mocked service
+                crowbarFactory.getEntity =
+                    sinon.spy(function () { return $q.when(entityResponseWithoutAddons); });
+
                 controller = $controller('UpgradeLandingController');
             });
 
@@ -150,9 +348,10 @@ describe('Upgrade Landing Controller', function() {
 
             describe('when checks pass successfully', function () {
                 beforeEach(function () {
-                    bard.mockService(upgradeFactory, {
-                        getPreliminaryChecks: $q.when(passingChecksResponse)
-                    });
+                    // local change in mocked service
+                    upgradeFactory.getPreliminaryChecks =
+                        sinon.spy(function () { return $q.when(passingChecksResponse); });
+
                     controller.prechecks.runPrechecks();
                     $rootScope.$digest();
                 });
@@ -175,9 +374,10 @@ describe('Upgrade Landing Controller', function() {
 
             describe('when checks fails', function () {
                 beforeEach(function () {
-                    bard.mockService(upgradeFactory, {
-                        getPreliminaryChecks: $q.when(failingChecksResponse)
-                    });
+                    // local change in mocked service
+                    upgradeFactory.getPreliminaryChecks =
+                        sinon.spy(function () { return $q.when(failingChecksResponse); });
+
                     controller.prechecks.runPrechecks();
                     $rootScope.$digest();
                 });
@@ -200,9 +400,10 @@ describe('Upgrade Landing Controller', function() {
 
             describe('when checks partially fail', function () {
                 beforeEach(function () {
-                    bard.mockService(upgradeFactory, {
-                        getPreliminaryChecks: $q.when(partiallyFailingChecksResponse)
-                    });
+                    // local change in mocked service
+                    upgradeFactory.getPreliminaryChecks =
+                        sinon.spy(function () { return $q.when(partiallyFailingChecksResponse); });
+
                     controller.prechecks.runPrechecks();
                     $rootScope.$digest();
                 });
@@ -225,9 +426,10 @@ describe('Upgrade Landing Controller', function() {
 
             describe('when service call fails', function () {
                 beforeEach(function () {
-                    bard.mockService(upgradeFactory, {
-                        getPreliminaryChecks: $q.reject(failingResponse)
-                    });
+                    // local change in mocked service
+                    upgradeFactory.getPreliminaryChecks =
+                        sinon.spy(function () { return $q.reject(failingResponse); });
+
                     controller.prechecks.runPrechecks();
                     $rootScope.$digest();
                 });
@@ -253,6 +455,49 @@ describe('Upgrade Landing Controller', function() {
 // @see: https://github.com/wardbell/bardjs#dont-use-appmodule-when-testing-routes
 describe('Upgrade Landing Controller - States', function () {
     var controller,
+        statusResponseData = {
+            current_step: 'upgrade_prechecks',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prepare: {
+                    status: 'pending',
+                },
+                upgrade_prechecks: {
+                    status: 'pending',
+                },
+                admin_backup: {
+                    status: 'pending',
+                },
+                admin_repo_checks: {
+                    status: 'pending',
+                },
+                admin_upgrade: {
+                    status: 'pending',
+                },
+                database: {
+                    status: 'pending',
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                },
+                nodes_services: {
+                    status: 'pending',
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                },
+                finished: {
+                    status: 'pending',
+                }
+            }
+        },
+        statusResponse = {
+            data: statusResponseData,
+        },
         entityResponseWithoutAddons = {
             data: {
                 addons: []
@@ -273,6 +518,10 @@ describe('Upgrade Landing Controller - States', function () {
             getEntity: $q.when(entityResponseWithoutAddons)
         });
 
+        bard.mockService(upgradeFactory, {
+            getStatus: $q.when(statusResponse),
+            prepareNodes: $q.when(),
+        });
 
         controller = $controller('UpgradeLandingController');
 
@@ -294,10 +543,6 @@ describe('Upgrade Landing Controller - States', function () {
 
     describe('when node prepare starts successfully', function () {
         beforeEach(function () {
-            bard.mockService(upgradeFactory, {
-                prepareNodes: $q.when()
-            });
-
             spyOn(upgradeStatusFactory, 'waitForStepToEnd');
 
             controller.prechecks.completed = true;
@@ -315,9 +560,9 @@ describe('Upgrade Landing Controller - States', function () {
 
     describe('when node prepare start fails', function () {
         beforeEach(function () {
-            bard.mockService(upgradeFactory, {
-                prepareNodes: $q.reject(errorResponse)
-            });
+            // local change in mocked service
+            upgradeFactory.prepareNodes =
+                sinon.spy(function () { return $q.reject(errorResponse); });
 
             spyOn(upgradeStatusFactory, 'waitForStepToEnd');
 
@@ -336,10 +581,6 @@ describe('Upgrade Landing Controller - States', function () {
 
     describe('when polling is finished successfully', function () {
         beforeEach(function () {
-            bard.mockService(upgradeFactory, {
-                prepareNodes: $q.when()
-            });
-
             bard.mockService(upgradeStatusFactory, {
                 waitForStepToEnd: function (step, onSuccess/*, onError, interval*/) { onSuccess(successResponse); }
             });
@@ -359,10 +600,6 @@ describe('Upgrade Landing Controller - States', function () {
 
     describe('when polling is finished with an error', function () {
         beforeEach(function () {
-            bard.mockService(upgradeFactory, {
-                prepareNodes: $q.when()
-            });
-
             bard.mockService(upgradeStatusFactory, {
                 waitForStepToEnd: function (step, onSuccess, onError/*, interval*/) { onError(errorResponse); }
             });

--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
@@ -237,7 +237,7 @@ describe('Upgrade Landing Controller', function() {
         });
 
         it('should start polling for status', function() {
-            expect(upgradeStatusFactory.waitForStepToEnd).toHaveBeenCalled();
+            expect(upgradeStatusFactory.waitForStepToEnd).toHaveBeenCalledTimes(1);
         });
 
         it('prepare should be running', function() {
@@ -249,7 +249,7 @@ describe('Upgrade Landing Controller', function() {
         });
     });
 
-    describe('when created while prepare is finished', function() {
+    describe('when created after prepare is finished', function() {
         beforeEach(function() {
             // local change in mocked service
             upgradeFactory.getStatus =

--- a/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
@@ -43,22 +43,10 @@
             // the button status and the update check running
             // TODO(itxaka): Not tested yet, tests should be done as part of card:
             // https://trello.com/c/5fXGm1a7/45-2-27-restore-last-step
-            upgradeFactory.getStatus()
-                .then(
-                    function (response) {
-                        vm.adminUpgrade.running =
-                            response.data.steps.admin_upgrade.status == UPGRADE_STEP_STATES.running;
-                        vm.adminUpgrade.completed =
-                            response.data.steps.admin_upgrade.status == UPGRADE_STEP_STATES.passed;
-                        if (vm.adminUpgrade.completed) {
-                            upgradeStepsFactory.setCurrentStepCompleted();
-                        } else if (vm.adminUpgrade.running) {
-                            waitForUpgradeToEnd();
-                        }
-                    },
-                    function (/*errorResponse*/) {
-                    }
-                );
+            upgradeStatusFactory.syncStatusFlags(
+                UPGRADE_STEPS.admin_upgrade, vm.adminUpgrade,
+                waitForUpgradeToEnd, upgradeStepsFactory.setCurrentStepCompleted
+            );
         }
 
         function beginAdminUpgrade() {

--- a/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
@@ -14,7 +14,7 @@
     UpgradeUpgradeAdministrationServerController.$inject = [
         '$timeout', 'crowbarFactory', 'upgradeStatusFactory',
         'ADMIN_UPGRADE_TIMEOUT_INTERVAL', 'ADMIN_UPGRADE_ALLOWED_DOWNTIME',
-        'UPGRADE_STEPS', 'UPGRADE_STEP_STATES', 'upgradeFactory', 'upgradeStepsFactory'
+        'UPGRADE_STEPS', 'UPGRADE_STEP_STATES', 'upgradeStepsFactory'
     ];
     // @ngInject
     function UpgradeUpgradeAdministrationServerController(
@@ -25,7 +25,6 @@
       ADMIN_UPGRADE_ALLOWED_DOWNTIME,
       UPGRADE_STEPS,
       UPGRADE_STEP_STATES,
-      upgradeFactory,
       upgradeStepsFactory
     ) {
         var vm = this;

--- a/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.spec.js
@@ -1,163 +1,17 @@
 /* global bard $controller should $httpBackend upgradeStatusFactory
-   upgradeFactory crowbarFactory assert $q $rootScope */
+   crowbarFactory assert $q $rootScope */
 describe('Upgrade Flow - Upgrade Administration Server Controller', function () {
-    var controller,
-        completedUpgradeResponseData = {
-            current_step: 'admin_upgrade',
-            substep: null,
-            current_node: null,
-            steps: {
-                upgrade_prechecks: {
-                    status: 'passed',
-                    errors: {}
-                },
-                admin_backup: {
-                    status: 'passed',
-                    errors: {}
-                },
-                admin_repo_checks: {
-                    status: 'passed',
-                    errors: {}
-                },
-                admin_upgrade: {
-                    status: 'passed',
-                    errors: {}
-                },
-                database: {
-                    status: 'pending',
-                    errors: {}
-                },
-                nodes_repo_checks: {
-                    status: 'pending',
-                    errors: {}
-                },
-                nodes_services: {
-                    status: 'pending',
-                    errors: {}
-                },
-                nodes_db_dump: {
-                    status: 'pending',
-                    errors: {}
-                },
-                nodes_upgrade: {
-                    status: 'pending',
-                    errors: {}
-                },
-                finished: {
-                    status: 'pending',
-                    errors: {}
-                }
-            }
-        },
-        incompleteUpgradeResponseData = {
-            current_step: 'admin_upgrade',
-            substep: null,
-            current_node: null,
-            steps: {
-                upgrade_prechecks: {
-                    status: 'passed',
-                    errors: {}
-                },
-                admin_backup: {
-                    status: 'passed',
-                    errors: {}
-                },
-                admin_repo_checks: {
-                    status: 'passed',
-                    errors: {}
-                },
-                admin_upgrade: {
-                    status: 'running',
-                    errors: {}
-                },
-                database: {
-                    status: 'pending',
-                    errors: {}
-                },
-                nodes_repo_checks: {
-                    status: 'pending',
-                    errors: {}
-                },
-                nodes_services: {
-                    status: 'pending',
-                    errors: {}
-                },
-                nodes_db_dump: {
-                    status: 'pending',
-                    errors: {}
-                },
-                nodes_upgrade: {
-                    status: 'pending',
-                    errors: {}
-                },
-                finished: {
-                    status: 'pending',
-                    errors: {}
-                }
-            }
-        },
-        initialResponseData = {
-            current_step: 'admin_upgrade',
-            substep: null,
-            current_node: null,
-            steps: {
-                upgrade_prechecks: {
-                    status: 'passed',
-                    errors: {}
-                },
-                admin_backup: {
-                    status: 'passed',
-                    errors: {}
-                },
-                admin_repo_checks: {
-                    status: 'passed',
-                    errors: {}
-                },
-                admin_upgrade: {
-                    status: 'pending',
-                    errors: {}
-                },
-                database: {
-                    status: 'pending',
-                    errors: {}
-                },
-                nodes_repo_checks: {
-                    status: 'pending',
-                    errors: {}
-                },
-                nodes_services: {
-                    status: 'pending',
-                    errors: {}
-                },
-                nodes_db_dump: {
-                    status: 'pending',
-                    errors: {}
-                },
-                nodes_upgrade: {
-                    status: 'pending',
-                    errors: {}
-                },
-                finished: {
-                    status: 'pending',
-                    errors: {}
-                }
-            }
-        },
-        activeStatusResponse = { data: null };
+    var controller;
 
     beforeEach(function() {
         //Setup the module and dependencies to be used.
         bard.appModule('crowbarApp.upgrade');
         bard.inject(
             '$controller', '$q', '$httpBackend', '$rootScope',
-            'crowbarFactory', 'upgradeFactory', 'upgradeStatusFactory'
+            'crowbarFactory', 'upgradeStatusFactory'
         );
 
-        // reset the active response to the default values
-        activeStatusResponse.data = initialResponseData;
-        bard.mockService(upgradeFactory, {
-            getStatus: $q.when(activeStatusResponse)
-        });
+        spyOn(upgradeStatusFactory, 'syncStatusFlags');
 
         //Create the controller
         controller = $controller('UpgradeUpgradeAdministrationServerController');
@@ -175,22 +29,10 @@ describe('Upgrade Flow - Upgrade Administration Server Controller', function () 
     });
 
     describe('on controller creation', function () {
-        it('should set running to true if the upgrade is running', function () {
-            activeStatusResponse.data = incompleteUpgradeResponseData;
-            // recreate the controller so it can pick our modified initialResponse
-            controller = $controller('UpgradeUpgradeAdministrationServerController');
-            $rootScope.$digest();
-            // initial model should have changed based on the initialization response
-            assert.isFalse(controller.adminUpgrade.completed);
-            assert.isTrue(controller.adminUpgrade.running);
-        });
-
-        it('should set completed to true if upgrade is completed', function () {
-            activeStatusResponse.data = completedUpgradeResponseData;
-            controller = $controller('UpgradeUpgradeAdministrationServerController');
-            $rootScope.$digest();
-            assert.isTrue(controller.adminUpgrade.completed);
-            assert.isFalse(controller.adminUpgrade.running);
+        it('should call syncStatusFlags() to update the state', function () {
+            expect(upgradeStatusFactory.syncStatusFlags).toHaveBeenCalledWith(
+                'admin_upgrade', controller.adminUpgrade, jasmine.any(Function), jasmine.any(Function)
+            );
         });
     });
 
@@ -249,11 +91,11 @@ describe('Upgrade Flow - Upgrade Administration Server Controller - errors', fun
         bard.appModule('crowbarApp.upgrade');
         bard.inject(
             '$controller', '$q', '$httpBackend', '$rootScope',
-            'crowbarFactory', 'upgradeFactory', 'upgradeStatusFactory'
+            'crowbarFactory', 'upgradeStatusFactory'
         );
 
-        bard.mockService(upgradeFactory, {
-            getStatus: $q.reject(errorResponse)
+        bard.mockService(upgradeStatusFactory, {
+            syncStatusFlags: undefined,
         });
 
         //Create the controller

--- a/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.spec.js
@@ -1,5 +1,5 @@
 /* global bard $controller should $httpBackend upgradeStatusFactory
-   crowbarFactory assert $q $rootScope */
+   crowbarFactory assert $q $rootScope upgradeStepsFactory */
 describe('Upgrade Flow - Upgrade Administration Server Controller', function () {
     var controller;
 
@@ -8,10 +8,11 @@ describe('Upgrade Flow - Upgrade Administration Server Controller', function () 
         bard.appModule('crowbarApp.upgrade');
         bard.inject(
             '$controller', '$q', '$httpBackend', '$rootScope',
-            'crowbarFactory', 'upgradeStatusFactory'
+            'crowbarFactory', 'upgradeStatusFactory', 'upgradeStepsFactory'
         );
 
         spyOn(upgradeStatusFactory, 'syncStatusFlags');
+        spyOn(upgradeStepsFactory, 'setCurrentStepCompleted');
 
         //Create the controller
         controller = $controller('UpgradeUpgradeAdministrationServerController');
@@ -31,7 +32,8 @@ describe('Upgrade Flow - Upgrade Administration Server Controller', function () 
     describe('on controller creation', function () {
         it('should call syncStatusFlags() to update the state', function () {
             expect(upgradeStatusFactory.syncStatusFlags).toHaveBeenCalledWith(
-                'admin_upgrade', controller.adminUpgrade, jasmine.any(Function), jasmine.any(Function)
+                'admin_upgrade', controller.adminUpgrade,
+                jasmine.any(Function), upgradeStepsFactory.setCurrentStepCompleted
             );
         });
     });

--- a/assets/app/features/upgrade/templates/landing-page.jade
+++ b/assets/app/features/upgrade/templates/landing-page.jade
@@ -14,7 +14,8 @@
             crowbar-checklist(checklist='upgradeLandingVm.prechecks.checks', completed='upgradeLandingVm.prechecks.completed')
 
             button.btn.btn-success(
-                ng-disabled="(upgradeLandingVm.prechecks.completed && upgradeLandingVm.prechecks.valid) || upgradeLandingVm.prechecks.running",
+                ng-disabled="(upgradeLandingVm.prechecks.completed && upgradeLandingVm.prechecks.valid) || \
+                    upgradeLandingVm.prechecks.running || upgradeLandingVm.prepare.running",
                 ng-class="{\
                     'spinner-visible': upgradeLandingVm.prechecks.spinnerVisible,\
                     active: upgradeLandingVm.prechecks.running\


### PR DESCRIPTION
When "prepare" step is in progress UI polls for status to detect
when step is finished. The polling is started when user clicks
"Begin Upgrade" button.

When page is refreshed or opened while the step is already running
the UI needs to automatically switch to "waiting" state.