### PR TITLE
upgrade: Restore last step on refresh or reopen

### DIFF
--- a/.eslintrc.angular.js
+++ b/.eslintrc.angular.js
@@ -5,6 +5,7 @@ module.exports = {
     ],
     'globals': {
         '_': true,
+        'localStorage': true,
         'bard': true
     },
     'env': {

--- a/assets/app/crowbar-app.module.js
+++ b/assets/app/crowbar-app.module.js
@@ -21,7 +21,6 @@
             'crowbarApp.upgrade'
         ])
         .config(configuration)
-        .run(run)
         // lodash support
         .constant('_', _);
 
@@ -36,28 +35,5 @@
             // For any unmatched url, redirect to /upgrade/prepare
             $urlRouterProvider.otherwise('/upgrade/landing');
         }
-    }
-
-    run.$inject = ['$rootScope', '$state', 'upgradeFactory', 'upgradeStepsFactory'];
-
-    function run($rootScope, $state, upgradeFactory, upgradeStepsFactory) {
-        var cleanup = $rootScope.$on('$stateChangeStart',
-                function(event, toState/*, toParams, fromState, fromParams*/) {
-                    upgradeFactory.getStatus()
-                        .then(
-                            function (response) {
-                                var expectedState = upgradeStepsFactory.lastStateForRestore(response.data);
-
-                                if (toState.name !== expectedState) {
-                                    event.preventDefault();
-                                    $state.go(expectedState)
-                                        .then(function () { upgradeStepsFactory.refeshStepsList(); });
-                                }
-                            },
-                            function (/*errorResponse*/) {
-                            }
-                        );
-                });
-        $rootScope.$on('$destroy', cleanup);
     }
 })(_);

--- a/assets/app/features/upgrade/steps.factory.js
+++ b/assets/app/features/upgrade/steps.factory.js
@@ -145,7 +145,6 @@
         /**
          * Handler for ui-router state change events to ensure requested page matches current backend status
          * For parameter descriptions see: https://github.com/angular-ui/ui-router/wiki#state-change-events
-         * @return {string}
          */
         function validateRequestedState(event, toState/*, toParams, fromState, fromParams*/) {
             upgradeFactory.getStatus()

--- a/assets/app/features/upgrade/steps.factory.js
+++ b/assets/app/features/upgrade/steps.factory.js
@@ -4,9 +4,9 @@
         .module('crowbarApp.upgrade')
         .factory('upgradeStepsFactory', upgradeStepsFactory);
 
-    upgradeStepsFactory.$inject = ['$state', 'upgradeFactory', 'STEP_STATES', 'UPGRADE_LAST_STATE_KEY'];
+    upgradeStepsFactory.$inject = ['$state', 'upgradeFactory', 'UPGRADE_STEP_STATES', 'UPGRADE_LAST_STATE_KEY'];
     /* @ngInject */
-    function upgradeStepsFactory($state, upgradeFactory, STEP_STATES, UPGRADE_LAST_STATE_KEY) {
+    function upgradeStepsFactory($state, upgradeFactory, UPGRADE_STEP_STATES, UPGRADE_LAST_STATE_KEY) {
         var factory = {
             steps: initialSteps(),
             stepByState: stepByState,
@@ -104,7 +104,7 @@
 
         /**
          * Validate if the active step is the last avilable step
-         * @return boolean
+         * @return {Boolean}
          */
         function isLastStep() {
             return factory.steps[factory.steps.length - 1] === factory.activeStep;
@@ -128,6 +128,7 @@
 
         /**
          * Return step data for given state
+         * @return {string}
          */
         function stepByState(state) {
             return _.find(factory.steps, function (step) { return step.state === state; });
@@ -135,6 +136,7 @@
 
         /**
          * Return step data for given id
+         * @return {string}
          */
         function stepByID(id) {
             return _.find(factory.steps, function (step) { return step.id === id; });
@@ -142,6 +144,8 @@
 
         /**
          * Handler for ui-router state change events to ensure requested page matches current backend status
+         * For parameter descriptions see: https://github.com/angular-ui/ui-router/wiki#state-change-events
+         * @return {string}
          */
         function validateRequestedState(event, toState/*, toParams, fromState, fromParams*/) {
             upgradeFactory.getStatus()
@@ -162,6 +166,7 @@
 
         /**
          * For given `map`, return keys mapping to `wantedValue`
+         * @return {Array} List of keys filtered by value
          */
         function keysForValue(map, wantedValue) {
             var keys = [];
@@ -175,6 +180,8 @@
 
         /**
          * Return ui-router state appropriate for current backend status
+         * @param {Object} Status data received from status API
+         * @return {string}
          */
         function lastStateForRestore(statusData) {
             var stepToStateMap = {
@@ -195,7 +202,7 @@
                 currentState = stepToStateMap[currentStep];
 
             // select previous step if current is still pending and previous step has a different page
-            if (steps[currentStep].status === STEP_STATES.pending) {
+            if (steps[currentStep].status === UPGRADE_STEP_STATES.pending) {
                 var storedLastState = localStorage.getItem(UPGRADE_LAST_STATE_KEY);
 
                 // if there is some stored state and it's pointing to page for current pending step

--- a/assets/app/features/upgrade/steps.factory.js
+++ b/assets/app/features/upgrade/steps.factory.js
@@ -4,11 +4,14 @@
         .module('crowbarApp.upgrade')
         .factory('upgradeStepsFactory', upgradeStepsFactory);
 
-    upgradeStepsFactory.$inject = ['$state'];
+    upgradeStepsFactory.$inject = ['$state', 'STEP_STATES', 'UPGRADE_LAST_STATE_KEY'];
     /* @ngInject */
-    function upgradeStepsFactory($state) {
+    function upgradeStepsFactory($state, STEP_STATES, UPGRADE_LAST_STATE_KEY) {
         var factory = {
             steps: initialSteps(),
+            stepByState: stepByState,
+            stepByID: stepByID,
+            lastStateForRestore: lastStateForRestore,
             activeStep: {},
             refeshStepsList: refeshStepsList,
             setCurrentStepCompleted: setCurrentStepCompleted,
@@ -94,6 +97,67 @@
                     finished: false
                 }
             ];
+        }
+
+        function stepByState(state) {
+            return _.find(factory.steps, function (o) { return o.state === state; });
+        }
+
+        function stepByID(id) {
+            return _.find(factory.steps, function (o) { return o.id === id; });
+        }
+
+        function lastStateForRestore(statusData) {
+            var mapping = {
+                'upgrade_prechecks': 'upgrade-landing',
+                'upgrade_prepare': 'upgrade-landing',
+                'admin_backup': 'upgrade.backup',
+                'admin_repo_checks': 'upgrade.administration-repository-checks',
+                'admin_upgrade': 'upgrade.upgrade-administration-server',
+                'database': 'upgrade.database-configuration',
+                'nodes_repo_checks': 'upgrade.nodes-repositories-checks',
+                'nodes_services': 'upgrade.openstack-services',
+                'nodes_db_dump': 'upgrade.openstack-services',
+                'nodes_upgrade': 'upgrade.upgrade-nodes',
+                'finished': 'TODO(skazi): no UI for this step yet',
+            };
+
+            var currentStep = statusData.current_step,
+                steps = statusData.steps,
+                currentState = mapping[currentStep];
+
+            // select previous step if current is still pending
+            if (steps[currentStep].status === STEP_STATES.pending) {
+                var storedLastState = localStorage.getItem(UPGRADE_LAST_STATE_KEY);
+
+                // if there is some stored state and it's pointing to page for current pending step
+                // show this instead of the previous one, otherwise apply the logic below to find
+                // proper page to show
+                if (storedLastState === currentState) {
+                    return currentState;
+                }
+
+                var currentStepData = stepByState(currentState);
+
+                // getting `undefined` from `stepByState()` should happen only
+                // for landing page which is not included in the wizard UI.
+                if (angular.isDefined(currentStepData)) {
+                    if (currentStepData.id > 0) {
+                        return stepByID(currentStepData.id - 1).state;
+                    } else {
+                        // don't move user back from backup page to landing page
+                        // this would require another "prepare" call to move forward
+                    }
+                } else if (currentState === 'upgrade-landing'){
+                    // this is the only valid case when expectedStep can be undefined
+                    // expectedState is already on landing page so nothing needs to be done
+                    // keeping this empty block here to make logic clear
+                } else {
+                    // TODO(skazi): this should never happen (error)
+                }
+            }
+
+            return currentState;
         }
     }
 })();

--- a/assets/app/features/upgrade/steps.factory.js
+++ b/assets/app/features/upgrade/steps.factory.js
@@ -100,15 +100,15 @@
         }
 
         function stepByState(state) {
-            return _.find(factory.steps, function (o) { return o.state === state; });
+            return _.find(factory.steps, function (step) { return step.state === state; });
         }
 
         function stepByID(id) {
-            return _.find(factory.steps, function (o) { return o.id === id; });
+            return _.find(factory.steps, function (step) { return step.id === id; });
         }
 
         function lastStateForRestore(statusData) {
-            var mapping = {
+            var stepToStateMap = {
                 'upgrade_prechecks': 'upgrade-landing',
                 'upgrade_prepare': 'upgrade-landing',
                 'admin_backup': 'upgrade.backup',
@@ -124,7 +124,7 @@
 
             var currentStep = statusData.current_step,
                 steps = statusData.steps,
-                currentState = mapping[currentStep];
+                currentState = stepToStateMap[currentStep];
 
             // select previous step if current is still pending
             if (steps[currentStep].status === STEP_STATES.pending) {

--- a/assets/app/features/upgrade/steps.factory.js
+++ b/assets/app/features/upgrade/steps.factory.js
@@ -226,17 +226,15 @@
                 if (angular.isDefined(currentStepData)) {
                     if (currentStepData.id > 0) {
                         return stepByID(currentStepData.id - 1).state;
-                    } else {
+                    } /* else {
                         // don't move user back from backup page to landing page
                         // this would require another "prepare" call to move forward
-                    }
-                } else if (currentState === 'upgrade-landing'){
+                    }*/
+                } /* else if (currentState === 'upgrade-landing'){
                     // this is the only valid case when expectedStep can be undefined
                     // expectedState is already on landing page so nothing needs to be done
                     // keeping this empty block here to make logic clear
-                } else {
-                    // TODO(skazi): this should never happen (error)
-                }
+                }*/
             }
 
             return currentState;

--- a/assets/app/features/upgrade/steps.factory.spec.js
+++ b/assets/app/features/upgrade/steps.factory.spec.js
@@ -1,4 +1,4 @@
-/*global bard should assert expect upgradeStepsFactory module $state*/
+/*global bard should assert expect upgradeStepsFactory module $state UPGRADE_LAST_STATE_KEY */
 describe('Stepes Factory', function () {
     var mockedInitialSteps = [
         {
@@ -50,12 +50,292 @@ describe('Stepes Factory', function () {
             active: false,
             finished: false
         }
-    ];
+        ],
+        initialStatusData = {
+            current_step: 'upgrade_prechecks',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'pending',
+                },
+                upgrade_prepare: {
+                    status: 'pending',
+                },
+                admin_backup: {
+                    status: 'pending',
+                },
+                admin_repo_checks: {
+                    status: 'pending',
+                },
+                admin_upgrade: {
+                    status: 'pending',
+                },
+                database: {
+                    status: 'pending',
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                },
+                nodes_services: {
+                    status: 'pending',
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                },
+                finished: {
+                    status: 'pending',
+                }
+            }
+        },
+        statusDataAfterPrechecks = {
+            current_step: 'upgrade_prepare',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                },
+                upgrade_prepare: {
+                    status: 'pending',
+                },
+                admin_backup: {
+                    status: 'pending',
+                },
+                admin_repo_checks: {
+                    status: 'pending',
+                },
+                admin_upgrade: {
+                    status: 'pending',
+                },
+                database: {
+                    status: 'pending',
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                },
+                nodes_services: {
+                    status: 'pending',
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                },
+                finished: {
+                    status: 'pending',
+                }
+            }
+        },
+        statusDataDuringPrepare = {
+            current_step: 'upgrade_prepare',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                },
+                upgrade_prepare: {
+                    status: 'running',
+                },
+                admin_backup: {
+                    status: 'pending',
+                },
+                admin_repo_checks: {
+                    status: 'pending',
+                },
+                admin_upgrade: {
+                    status: 'pending',
+                },
+                database: {
+                    status: 'pending',
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                },
+                nodes_services: {
+                    status: 'pending',
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                },
+                finished: {
+                    status: 'pending',
+                }
+            }
+        },
+        statusDataAfterPrepare = {
+            current_step: 'admin_backup',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                },
+                upgrade_prepare: {
+                    status: 'passed',
+                },
+                admin_backup: {
+                    status: 'pending',
+                },
+                admin_repo_checks: {
+                    status: 'pending',
+                },
+                admin_upgrade: {
+                    status: 'pending',
+                },
+                database: {
+                    status: 'pending',
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                },
+                nodes_services: {
+                    status: 'pending',
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                },
+                finished: {
+                    status: 'pending',
+                }
+            }
+        },
+        statusDataDuringBackup = {
+            current_step: 'admin_backup',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                },
+                upgrade_prepare: {
+                    status: 'passed',
+                },
+                admin_backup: {
+                    status: 'running',
+                },
+                admin_repo_checks: {
+                    status: 'pending',
+                },
+                admin_upgrade: {
+                    status: 'pending',
+                },
+                database: {
+                    status: 'pending',
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                },
+                nodes_services: {
+                    status: 'pending',
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                },
+                finished: {
+                    status: 'pending',
+                }
+            }
+        },
+        statusDataAfterBackup = {
+            current_step: 'admin_repo_checks',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                },
+                upgrade_prepare: {
+                    status: 'passed',
+                },
+                admin_backup: {
+                    status: 'passed',
+                },
+                admin_repo_checks: {
+                    status: 'pending',
+                },
+                admin_upgrade: {
+                    status: 'pending',
+                },
+                database: {
+                    status: 'pending',
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                },
+                nodes_services: {
+                    status: 'pending',
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                },
+                finished: {
+                    status: 'pending',
+                }
+            }
+        },
+        statusDataAfterAdminRepoChecks = {
+            current_step: 'admin_upgrade',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                },
+                upgrade_prepare: {
+                    status: 'passed',
+                },
+                admin_backup: {
+                    status: 'passed',
+                },
+                admin_repo_checks: {
+                    status: 'passed',
+                },
+                admin_upgrade: {
+                    status: 'pending',
+                },
+                database: {
+                    status: 'pending',
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                },
+                nodes_services: {
+                    status: 'pending',
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                },
+                finished: {
+                    status: 'pending',
+                }
+            }
+        };
 
     beforeEach(function () {
         //Setup the module and dependencies to be used.
         module('crowbarApp.upgrade');
-        bard.inject('upgradeStepsFactory', '$state');
+        bard.inject('upgradeStepsFactory', '$state', 'UPGRADE_LAST_STATE_KEY');
 
     });
 
@@ -74,6 +354,14 @@ describe('Stepes Factory', function () {
 
         it('returns an object with refeshStepsList function is defined', function () {
             expect(upgradeStepsFactory.refeshStepsList).toEqual(jasmine.any(Function));
+        });
+
+        it('returns an object with stepByState function defined', function () {
+            expect(upgradeStepsFactory.stepByState).toEqual(jasmine.any(Function));
+        });
+
+        it('returns an object with stepByID function defined', function () {
+            expect(upgradeStepsFactory.stepByID).toEqual(jasmine.any(Function));
         });
 
         describe('steps array', function () {
@@ -118,5 +406,87 @@ describe('Stepes Factory', function () {
             });
 
         });
+
+        describe('stepByState function', function () {
+            _.forEach(mockedInitialSteps, function (mockedStep) {
+                it('should return step with state=' + mockedStep.state + ' when called', function () {
+                    expect(upgradeStepsFactory.stepByState(mockedStep.state)).toEqual(mockedStep);
+                });
+            });
+
+            it('should return undefined when called with nonexistent state', function () {
+                expect(upgradeStepsFactory.stepByState('--dummy state--')).not.toBeDefined();
+            });
+        });
+
+        describe('stepByID function', function () {
+            _.forEach(mockedInitialSteps, function (mockedStep) {
+                it('should return step with ID=' + mockedStep.id + ' when called', function () {
+                    expect(upgradeStepsFactory.stepByID(mockedStep.id)).toEqual(mockedStep);
+                });
+            });
+
+            it('should return undefined when called with nonexistent ID', function () {
+                expect(upgradeStepsFactory.stepByID(-1)).not.toBeDefined();
+                expect(upgradeStepsFactory.stepByID(9999)).not.toBeDefined();
+            });
+        });
+
+        describe('lastStateForRestore function', function () {
+            describe('when there is no stored last state', function () {
+                beforeEach(function () {
+                    localStorage.removeItem(UPGRADE_LAST_STATE_KEY);
+                });
+                it('should return "upgrade-landing" before any step', function() {
+                    expect(upgradeStepsFactory.lastStateForRestore(initialStatusData))
+                        .toEqual('upgrade-landing');
+                });
+                it('should return "upgrade-landing" after prechecks', function() {
+                    expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterPrechecks))
+                        .toEqual('upgrade-landing');
+                });
+                it('should return "upgrade-landing" during prepare', function() {
+                    expect(upgradeStepsFactory.lastStateForRestore(statusDataDuringPrepare))
+                        .toEqual('upgrade-landing');
+                });
+                it('should return "upgrade.backup" after prepare', function() {
+                    expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterPrepare))
+                        .toEqual('upgrade.backup');
+                });
+                it('should return "upgrade.backup" during backup', function() {
+                    expect(upgradeStepsFactory.lastStateForRestore(statusDataDuringBackup))
+                        .toEqual('upgrade.backup');
+                });
+                it('should return "upgrade.backup" after backup', function() {
+                    expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterBackup))
+                        .toEqual('upgrade.backup');
+                });
+                it('should return "upgrade.administration-repository-checks" after admin repo checks', function() {
+                    expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterAdminRepoChecks))
+                        .toEqual('upgrade.administration-repository-checks');
+                });
+            });
+            describe('when stored state is invalid in given case', function () {
+                beforeEach(function () {
+                    localStorage.setItem(UPGRADE_LAST_STATE_KEY, 'upgrade-landing');
+                });
+                it('should return "upgrade.backup" after backup', function() {
+                    expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterBackup))
+                        .toEqual('upgrade.backup');
+                });
+            });
+            describe('when stored state points to current, pending step', function () {
+                beforeEach(function () {
+                    localStorage.setItem(UPGRADE_LAST_STATE_KEY, 'upgrade.administration-repository-checks');
+                });
+                it('should return "upgrade.administration-repository-checks" after backup', function() {
+                    expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterBackup))
+                        .toEqual('upgrade.administration-repository-checks');
+                });
+            });
+        });
+
     });
+
+
 });

--- a/assets/app/features/upgrade/steps.factory.spec.js
+++ b/assets/app/features/upgrade/steps.factory.spec.js
@@ -1,4 +1,4 @@
-/*global bard should assert expect upgradeStepsFactory module $state UPGRADE_LAST_STATE_KEY */
+/*global bard should assert expect upgradeStepsFactory module $state $q UPGRADE_LAST_STATE_KEY */
 describe('Stepes Factory', function () {
     var mockedInitialSteps = [
         {
@@ -329,14 +329,262 @@ describe('Stepes Factory', function () {
                 finished: {
                     status: 'pending',
                 }
+            },
+        },
+        statusDataAfterAdminUpgrade = {
+            current_step: 'database',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                },
+                upgrade_prepare: {
+                    status: 'passed',
+                },
+                admin_backup: {
+                    status: 'passed',
+                },
+                admin_repo_checks: {
+                    status: 'passed',
+                },
+                admin_upgrade: {
+                    status: 'passed',
+                },
+                database: {
+                    status: 'pending',
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                },
+                nodes_services: {
+                    status: 'pending',
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                },
+                finished: {
+                    status: 'pending',
+                }
+            }
+        },
+        statusDataAfterDatabase = {
+            current_step: 'nodes_repo_checks',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                },
+                upgrade_prepare: {
+                    status: 'passed',
+                },
+                admin_backup: {
+                    status: 'passed',
+                },
+                admin_repo_checks: {
+                    status: 'passed',
+                },
+                admin_upgrade: {
+                    status: 'passed',
+                },
+                database: {
+                    status: 'passed',
+                },
+                nodes_repo_checks: {
+                    status: 'pending',
+                },
+                nodes_services: {
+                    status: 'pending',
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                },
+                finished: {
+                    status: 'pending',
+                }
+            }
+        },
+        statusDataAfterNodesRepoChecks = {
+            current_step: 'nodes_services',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                },
+                upgrade_prepare: {
+                    status: 'passed',
+                },
+                admin_backup: {
+                    status: 'passed',
+                },
+                admin_repo_checks: {
+                    status: 'passed',
+                },
+                admin_upgrade: {
+                    status: 'passed',
+                },
+                database: {
+                    status: 'passed',
+                },
+                nodes_repo_checks: {
+                    status: 'passed',
+                },
+                nodes_services: {
+                    status: 'pending',
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                },
+                finished: {
+                    status: 'pending',
+                }
+            }
+        },
+        statusDataAfterNodesServices = {
+            current_step: 'nodes_db_dump',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                },
+                upgrade_prepare: {
+                    status: 'passed',
+                },
+                admin_backup: {
+                    status: 'passed',
+                },
+                admin_repo_checks: {
+                    status: 'passed',
+                },
+                admin_upgrade: {
+                    status: 'passed',
+                },
+                database: {
+                    status: 'passed',
+                },
+                nodes_repo_checks: {
+                    status: 'passed',
+                },
+                nodes_services: {
+                    status: 'passed',
+                },
+                nodes_db_dump: {
+                    status: 'pending',
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                },
+                finished: {
+                    status: 'pending',
+                }
+            }
+        },
+        statusDataAfterNodesDBDump = {
+            current_step: 'nodes_upgrade',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                },
+                upgrade_prepare: {
+                    status: 'passed',
+                },
+                admin_backup: {
+                    status: 'passed',
+                },
+                admin_repo_checks: {
+                    status: 'passed',
+                },
+                admin_upgrade: {
+                    status: 'passed',
+                },
+                database: {
+                    status: 'passed',
+                },
+                nodes_repo_checks: {
+                    status: 'passed',
+                },
+                nodes_services: {
+                    status: 'passed',
+                },
+                nodes_db_dump: {
+                    status: 'passed',
+                },
+                nodes_upgrade: {
+                    status: 'pending',
+                },
+                finished: {
+                    status: 'pending',
+                }
+            }
+        },
+        statusDataAfterNodesUpgrade = {
+            current_step: 'finished',
+            substep: null,
+            current_node: null,
+            steps: {
+                upgrade_prechecks: {
+                    status: 'passed',
+                },
+                upgrade_prepare: {
+                    status: 'passed',
+                },
+                admin_backup: {
+                    status: 'passed',
+                },
+                admin_repo_checks: {
+                    status: 'passed',
+                },
+                admin_upgrade: {
+                    status: 'passed',
+                },
+                database: {
+                    status: 'passed',
+                },
+                nodes_repo_checks: {
+                    status: 'passed',
+                },
+                nodes_services: {
+                    status: 'passed',
+                },
+                nodes_db_dump: {
+                    status: 'passed',
+                },
+                nodes_upgrade: {
+                    status: 'passed',
+                },
+                finished: {
+                    status: 'pending',
+                }
             }
         };
 
     beforeEach(function () {
         //Setup the module and dependencies to be used.
         module('crowbarApp.upgrade');
-        bard.inject('upgradeStepsFactory', '$state', 'UPGRADE_LAST_STATE_KEY');
+        bard.inject('upgradeStepsFactory', '$state', '$q', 'UPGRADE_LAST_STATE_KEY');
 
+        //Mock the $state service
+        bard.mockService($state, {
+            go : $q.when()
+        });
+        spyOn($state, 'go');
+
+        $state.current = {id: 0, name: 'upgrade.backup', state: 'upgrade.backup'};
+        upgradeStepsFactory.activeStep = upgradeStepsFactory.steps[0];
     });
 
     describe('when executed', function () {
@@ -407,6 +655,52 @@ describe('Stepes Factory', function () {
 
         });
 
+        describe('showNextStep function', function () {
+            it('should exist', function () {
+                should.exist(upgradeStepsFactory.showNextStep);
+                expect(upgradeStepsFactory.showNextStep).toEqual(jasmine.any(Function));
+            });
+
+            it('when called it should move to the next step', function () {
+                expect($state.current.id).toBe(0);
+                // calculate the next step in the list
+                var nextStep = (upgradeStepsFactory.steps[upgradeStepsFactory.activeStep.id + 1]).state;
+                upgradeStepsFactory.showNextStep();
+                expect($state.go).toHaveBeenCalledWith(nextStep);
+            });
+
+            it('when called in the last step it should not change steps', function () {
+                // set the last step in the list as current
+                $state.current = {id: 0, name: 'upgrade.upgrade-nodes', state: 'upgrade.upgrade-nodes'};
+                // set last step as active
+                upgradeStepsFactory.activeStep = upgradeStepsFactory.steps[upgradeStepsFactory.steps.length - 1];
+                upgradeStepsFactory.showNextStep();
+                // should have not called the state.go
+                expect($state.go).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('isLastStep function', function () {
+            it('should exist', function () {
+                should.exist(upgradeStepsFactory.isLastStep);
+                expect(upgradeStepsFactory.isLastStep).toEqual(jasmine.any(Function));
+            });
+
+            it('when called on the first step it should return false', function () {
+                // set the first step in the list as current
+                $state.current = {id: 0, name: 'upgrade.backup', state: 'upgrade.backup'};
+                expect(upgradeStepsFactory.isLastStep()).toBe(false);
+            });
+
+            it('when called on the last step it should return true', function () {
+                // set the last step in the list as current
+                $state.current = {id: 0, name: 'upgrade.upgrade-nodes', state: 'upgrade.upgrade-nodes'};
+                // set last step as active
+                upgradeStepsFactory.activeStep = upgradeStepsFactory.steps[upgradeStepsFactory.steps.length - 1];
+                expect(upgradeStepsFactory.isLastStep()).toBe(true);
+            });
+        });
+
         describe('stepByState function', function () {
             _.forEach(mockedInitialSteps, function (mockedStep) {
                 it('should return step with state=' + mockedStep.state + ' when called', function () {
@@ -464,6 +758,31 @@ describe('Stepes Factory', function () {
                 it('should return "upgrade.administration-repository-checks" after admin repo checks', function() {
                     expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterAdminRepoChecks))
                         .toEqual('upgrade.administration-repository-checks');
+                });
+
+                it('should return "upgrade.upgrade-administration-server" after admin upgrade', function() {
+                    expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterAdminUpgrade))
+                        .toEqual('upgrade.upgrade-administration-server');
+                });
+                it('should return "upgrade.database-configuration" after database configuration', function() {
+                    expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterDatabase))
+                        .toEqual('upgrade.database-configuration');
+                });
+                it('should return "upgrade.nodes-repositories-checks" after nodes repo checks', function() {
+                    expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterNodesRepoChecks))
+                        .toEqual('upgrade.nodes-repositories-checks');
+                });
+                it('should return "upgrade.openstack-services" after stoping services', function() {
+                    expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterNodesServices))
+                        .toEqual('upgrade.openstack-services');
+                });
+                it('should return "upgrade.openstack-services" after nodes db dump', function() {
+                    expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterNodesDBDump))
+                        .toEqual('upgrade.openstack-services');
+                });
+                it('should return "upgrade.upgrade-nodes" after nodes upgrade', function() {
+                    expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterNodesUpgrade))
+                        .toEqual('upgrade.upgrade-nodes');
                 });
             });
             describe('when stored state is invalid in given case', function () {

--- a/assets/app/features/upgrade/steps.factory.spec.js
+++ b/assets/app/features/upgrade/steps.factory.spec.js
@@ -785,7 +785,16 @@ describe('Stepes Factory', function () {
                         .toEqual('upgrade.upgrade-nodes');
                 });
             });
-            describe('when stored state is invalid in given case', function () {
+            describe('when stored state is invalid', function () {
+                beforeEach(function () {
+                    localStorage.setItem(UPGRADE_LAST_STATE_KEY, '--dummy--');
+                });
+                it('should return "upgrade.backup" after backup', function() {
+                    expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterBackup))
+                        .toEqual('upgrade.backup');
+                });
+            });
+            describe('when stored state is invalid in current context', function () {
                 beforeEach(function () {
                     localStorage.setItem(UPGRADE_LAST_STATE_KEY, 'upgrade-landing');
                 });

--- a/assets/app/features/upgrade/upgrade.constants.js
+++ b/assets/app/features/upgrade/upgrade.constants.js
@@ -12,6 +12,7 @@
             'ha': ['clusters_healthy'],
             'ceph': ['ceph_healthy']
         })
+        .constant('UPGRADE_LAST_STATE_KEY', 'soc.upgrade.lastUIState')
         .constant('PREPARE_TIMEOUT_INTERVAL', 1000)
         .constant('ADMIN_UPGRADE_ALLOWED_DOWNTIME', 30 * 60 * 1000)
         .constant('ADMIN_UPGRADE_TIMEOUT_INTERVAL', 5000);

--- a/assets/app/features/upgrade/upgrade.constants.js
+++ b/assets/app/features/upgrade/upgrade.constants.js
@@ -12,7 +12,7 @@
             'ha': ['clusters_healthy'],
             'ceph': ['ceph_healthy']
         })
-        .constant('UPGRADE_LAST_STATE_KEY', 'soc.upgrade.lastUIState')
+        .constant('UPGRADE_LAST_STATE_KEY', 'crowbar.upgrade.lastUIState')
         .constant('PREPARE_TIMEOUT_INTERVAL', 1000)
         .constant('ADMIN_UPGRADE_ALLOWED_DOWNTIME', 30 * 60 * 1000)
         .constant('ADMIN_UPGRADE_TIMEOUT_INTERVAL', 5000);

--- a/assets/app/features/upgrade/upgrade.controller.js
+++ b/assets/app/features/upgrade/upgrade.controller.js
@@ -27,8 +27,7 @@
         var vm = this;
         vm.steps = {
             list: [],
-            nextStep: nextStep,
-            isLastStep: isLastStep,
+            nextStep: upgradeStepsFactory.showNextStep,
             isCurrentStepCompleted: upgradeStepsFactory.isCurrentStepCompleted
         };
 
@@ -40,30 +39,6 @@
 
         // Watch for view changes on the Step in order to update the steps list.
         $scope.$on('$viewContentLoaded', upgradeStepsFactory.refeshStepsList);
-
-        /**
-         * Move to the next available Step
-         */
-        function nextStep() {
-            // Only move forward if active step isn't last step available
-            if (vm.steps.isLastStep()) {
-                return;
-            }
-
-            var nextState = vm.steps.list[upgradeStepsFactory.activeStep.id + 1].state;
-            // save new state in local storage for proper "restore last step" handling
-            localStorage.setItem(UPGRADE_LAST_STATE_KEY, nextState);
-
-            $state.go(nextState);
-        }
-
-        /**
-         * Validate if the active step is the last avilable step
-         * @return boolean
-         */
-        function isLastStep() {
-            return vm.steps.list[vm.steps.list.length - 1] === upgradeStepsFactory.activeStep;
-        }
 
         /**
          * Trigger cancellation of the upgrade process and go back to landing page

--- a/assets/app/features/upgrade/upgrade.module.js
+++ b/assets/app/features/upgrade/upgrade.module.js
@@ -2,5 +2,14 @@
     'use strict';
 
     angular
-        .module('crowbarApp.upgrade', ['ui.router', 'ngFileSaver', 'pascalprecht.translate', 'suseData']);
+        .module('crowbarApp.upgrade', ['ui.router', 'ngFileSaver', 'pascalprecht.translate', 'suseData'])
+        .run(run);
+
+    run.$inject = ['$rootScope', 'upgradeStepsFactory'];
+
+    function run($rootScope, upgradeStepsFactory) {
+        var cleanup = $rootScope.$on('$stateChangeStart', upgradeStepsFactory.validateRequestedState);
+        $rootScope.$on('$destroy', cleanup);
+    }
+
 })();

--- a/assets/app/features/upgrade/upgrade.module.js
+++ b/assets/app/features/upgrade/upgrade.module.js
@@ -7,6 +7,10 @@
 
     run.$inject = ['$rootScope', 'upgradeStepsFactory'];
 
+    /**
+     * This function is executed during module bootstrap. Event handlers which need to work in whole module
+     * are attached here.
+     */
     function run($rootScope, upgradeStepsFactory) {
         var cleanup = $rootScope.$on('$stateChangeStart', upgradeStepsFactory.validateRequestedState);
         $rootScope.$on('$destroy', cleanup);


### PR DESCRIPTION
When browser window is closed and reopened or refreshed during upgrade flow,
the user should be presented with the most appropriate view of the flow.
The UI will show the page respective for `current_step` as returned by the
status API and/or state stored in browser.

Same mechanism is used to prevent user from jumping to any page in the flow
by manually entering the page URL into the address bar.

Note: this PR is just implementation of the general mechanism. Proper handling of page refresh needs to be implemented for each page (except Admin Server Upgrade which was implemented before).
Refresh handling is done in following PRs: https://github.com/crowbar/crowbar-ui/pull/95, ...