### PR TITLE
upgrade: Admin backup page refresh handling

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-backup.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-backup.controller.js
@@ -18,9 +18,10 @@ function() {
         'crowbarUtilsFactory',
         '$document',
         'upgradeStepsFactory',
+        'upgradeStatusFactory',
         'upgradeFactory',
         'FileSaver',
-        'Blob'
+        'UPGRADE_STEPS',
     ];
     // @ngInject
     function UpgradeBackupController(
@@ -29,8 +30,10 @@ function() {
         crowbarUtilsFactory,
         $document,
         upgradeStepsFactory,
+        upgradeStatusFactory,
         upgradeFactory,
-        FileSaver
+        FileSaver,
+        UPGRADE_STEPS
     ) {
         var vm = this;
         vm.backup = {
@@ -40,6 +43,15 @@ function() {
             download: downloadBackup,
             spinnerVisible: false
         };
+
+        activate();
+
+        function activate() {
+            upgradeStatusFactory.syncStatusFlags(
+                UPGRADE_STEPS.admin_backup, vm.backup,
+                undefined,
+                upgradeStepsFactory.setCurrentStepCompleted);
+        }
 
         function createBackup() {
             vm.backup.running = true;

--- a/assets/app/features/upgrade/controllers/upgrade-backup.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-backup.controller.spec.js
@@ -1,5 +1,6 @@
 /* jshint -W117, -W030 */
-/*global bard $controller $httpBackend should assert $q $rootScope upgradeFactory Blob FileSaver crowbarUtilsFactory */
+/*global bard $controller $httpBackend should assert $q $rootScope upgradeFactory Blob FileSaver
+  crowbarUtilsFactory upgradeStatusFactory */
 describe('Upgrade Flow - Backup Controller', function() {
     var controller,
         mockedErrorList = [ 1, 2, 3],
@@ -33,9 +34,12 @@ describe('Upgrade Flow - Backup Controller', function() {
             '$q',
             '$httpBackend',
             'upgradeFactory',
+            'upgradeStatusFactory',
             'crowbarUtilsFactory',
             'FileSaver'
         );
+
+        spyOn(upgradeStatusFactory, 'syncStatusFlags');
 
         //Create the controller
         controller = $controller('UpgradeBackupController');
@@ -51,6 +55,10 @@ describe('Upgrade Flow - Backup Controller', function() {
 
     it('should exist', function() {
         should.exist(controller);
+    });
+
+    it('should sync status flags when activated', function () {
+        expect(upgradeStatusFactory.syncStatusFlags).toHaveBeenCalledTimes(1);
     });
 
     describe('Backup object', function() {


### PR DESCRIPTION
When admin server backup was created before page was (re)opened,
Next button should be enabled to avoid need to create another
backup in order to continue with upgrade