### PR TITLE
upgrade: remove timeout callback wrapper

### DIFF
--- a/assets/app/data/crowbar/services/upgrade-status.factory.js
+++ b/assets/app/data/crowbar/services/upgrade-status.factory.js
@@ -60,12 +60,10 @@
                             onSuccess(response);
                         } else {
                             // schedule another check
-                            $timeout(function () {
-                                factory.waitForStepToEnd(
-                                    step, onSuccess, onError,
-                                    pollingInterval, allowedDowntimeLeft
-                                );
-                            }, pollingInterval);
+                            $timeout(
+                                factory.waitForStepToEnd, pollingInterval, true,
+                                step, onSuccess, onError, pollingInterval, allowedDowntimeLeft
+                            );
                         }
                     },
                     function (errorResponse) {
@@ -74,12 +72,10 @@
                             onError(errorResponse);
                         } else {
                             // schedule another check but with less downtime allowance
-                            $timeout(function () {
-                                factory.waitForStepToEnd(
-                                    step, onSuccess, onError,
-                                    pollingInterval, allowedDowntimeLeft - pollingInterval
-                                );
-                            }, pollingInterval);
+                            $timeout(
+                                factory.waitForStepToEnd, pollingInterval, true,
+                                step, onSuccess, onError, pollingInterval, allowedDowntimeLeft - pollingInterval
+                            );
                         }
                     }
                 );

--- a/assets/app/data/crowbar/services/upgrade-status.factory.spec.js
+++ b/assets/app/data/crowbar/services/upgrade-status.factory.spec.js
@@ -2,6 +2,7 @@
 describe('Upgrade Status Factory', function () {
     var pollingInterval = 1234,
         testedStep = 'admin_upgrade',
+        allowedDowntime = 4321,
         completedUpgradeResponseData = {
             current_step: 'database',
             substep: null,
@@ -248,7 +249,7 @@ describe('Upgrade Status Factory', function () {
                         });
 
                         upgradeStatusFactory.waitForStepToEnd(
-                            testedStep, mockedSuccessCallback, mockedErrorCallback, pollingInterval
+                            testedStep, mockedSuccessCallback, mockedErrorCallback, pollingInterval, allowedDowntime
                         );
 
                         $rootScope.$digest();
@@ -261,7 +262,8 @@ describe('Upgrade Status Factory', function () {
                     });
                     it('should schedule another check', function () {
                         expect(mockedTimeout).toHaveBeenCalledWith(
-                            jasmine.any(Function), pollingInterval
+                            upgradeStatusFactory.waitForStepToEnd, pollingInterval, true,
+                            testedStep, mockedSuccessCallback, mockedErrorCallback, pollingInterval, allowedDowntime
                         );
                     });
                 });
@@ -275,7 +277,7 @@ describe('Upgrade Status Factory', function () {
                         });
 
                         upgradeStatusFactory.waitForStepToEnd(
-                            testedStep, mockedSuccessCallback, mockedErrorCallback, pollingInterval
+                            testedStep, mockedSuccessCallback, mockedErrorCallback, pollingInterval, 0
                         );
 
                         $rootScope.$digest();


### PR DESCRIPTION
This removes thin wrapper around function called by $timeout.
The wrapper was there to pass closure variables to the called
function. It turned out that $timeout has a native way of doing
this.

Removing this wrapper function has a nice side effect of improving
testability of the code.