### PR TITLE
upgrade: temporary dependency fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,13 +14,13 @@
   ],
   "dependencies": {
     "lodash": "^4.13.1",
-    "angular": "^1.5.6",
-    "angular-animate": "^1.5.6",
-    "angular-cookies": "^1.5.6",
-    "angular-resource": "^1.5.6",
-    "angular-route": "^1.5.6",
-    "angular-sanitize": "^1.5.6",
-    "angular-touch": "^1.5.6",
+    "angular": "1.5.9",
+    "angular-animate": "1.5.9",
+    "angular-cookies": "1.5.9",
+    "angular-resource": "1.5.9",
+    "angular-route": "1.5.9",
+    "angular-sanitize": "1.5.9",
+    "angular-touch": "1.5.9",
     "angular-translate": "^2.11.0",
     "angular-ui-router": "^0.3.1",
     "angular-loading-bar": "^0.9.0",
@@ -32,8 +32,11 @@
     "angular-translate-loader-partial": "^2.11.0"
   },
   "devDependencies": {
-    "angular-mocks": "^1.5.8",
+    "angular-mocks": "1.5.9",
     "bardjs": "^0.1.8",
     "sinon": "http://sinonjs.org/releases/sinon-1.17.5.js"
+  },
+  "resolutions": {
+    "angular": "1.5.9"
   }
 }


### PR DESCRIPTION
angular-translate doesn't support angular 1.6 yet.
see: angular-translate/angular-translate#1657

temporarily freezing angular module versions at 1.5.9