### PR TITLE
upgrade: Asynchronous StopServices and OpenStack Backup

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-openstack-services.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-openstack-services.controller.js
@@ -14,82 +14,164 @@
     UpgradeOpenStackServicesController.$inject = [
         '$translate',
         'upgradeFactory',
-        'upgradeStepsFactory'
+        'upgradeStepsFactory',
+        'upgradeStatusFactory',
+        'UPGRADE_STEPS',
+        'STOP_OPENSTACK_SERVICES_TIMEOUT_INTERVAL',
+        'OPENSTACK_BACKUP_TIMEOUT_INTERVAL',
     ];
     // @ngInject
-    function UpgradeOpenStackServicesController($translate, upgradeFactory, upgradeStepsFactory) {
+    function UpgradeOpenStackServicesController(
+        $translate,
+        upgradeFactory,
+        upgradeStepsFactory,
+        upgradeStatusFactory,
+        UPGRADE_STEPS,
+        STOP_OPENSTACK_SERVICES_TIMEOUT_INTERVAL,
+        OPENSTACK_BACKUP_TIMEOUT_INTERVAL
+    ) {
         var vm = this;
 
-        vm.openStackServices = {
-            valid: false,
-            completed: false,
-            running: false,
-            spinnerVisible: false,
-            checks: {
-                services: {
-                    status: false,
-                    label: 'upgrade.steps.openstack-services.codes.services'
-                },
-                backup: {
-                    status: false,
-                    label: 'upgrade.steps.openstack-services.codes.backup'
-                }
+        vm.checks = {
+            services: {
+                status: false,
+                completed: false,
+                running: false,
+                label: 'upgrade.steps.openstack-services.codes.services'
             },
-            stopServices: stopServices
+            backup: {
+                status: false,
+                completed: false,
+                running: false,
+                label: 'upgrade.steps.openstack-services.codes.backup'
+            }
         };
 
+        vm.openStackServices = {
+            spinnerVisible: false,
+            stopServices: stopServices,
+        };
+
+        vm.openStackBackup = {
+            createBackup: createBackup,
+        };
+
+        activate();
+
+        function activate() {
+            // sync backup status before services step sync
+            // to know if we need to auto-trigger backup or not.
+            upgradeStatusFactory.syncStatusFlags(
+                UPGRADE_STEPS.backup_openstack, vm.checks.backup,
+                waitForBackupToEnd, createBackupSuccess, createBackupError,
+                // postSync function to chain services sync after backup was synced
+                function () {
+                    upgradeStatusFactory.syncStatusFlags(
+                        UPGRADE_STEPS.services, vm.checks.services,
+                        waitForStopServicesToEnd, stopServicesSuccess, stopServicesError
+                    );
+                }
+            );
+
+        }
+
         /**
-         *  Validate OpenStackServices required for Cloud 7 Upgrade
+         *  Stop OpenStack services which are non-essential during upgrade
          */
         function stopServices() {
-            vm.openStackServices.running = true;
+            // re-starting after failed backup?
+            if (vm.checks.services.status) {
+                createBackup();
+                return;
+            }
+
+            vm.checks.services.running = true;
 
             upgradeFactory.stopServices()
                 .then(
                     //Success handler. Stop all OpenStackServices successfully:
-                    stopServicesSuccess,
+                    waitForStopServicesToEnd,
                     //Failure handler:
                     stopServicesError
                 );
+        }
 
-            function stopServicesSuccess () {
-                vm.openStackServices.checks.services.status =
-                    vm.openStackServices.valid = true;
+        function stopServicesSuccess(/*response*/) {
+            vm.checks.services.running = false;
+            vm.checks.services.status = true;
+            vm.checks.services.completed = true;
 
-                upgradeFactory.createOpenstackBackup()
-                    .then(
-                        //Success handler. Backup OpenStackServices successfully:
-                        createBackupSuccess,
-                        //Failure handler:
-                        createBackupError
-                    ).finally(function() {
-                        vm.openStackServices.completed = true;
-                        // Update openStackServices validity
-                        vm.openStackServices.running = false;
+            // trigger backup creation
+            createBackup();
+        }
 
-                        vm.openStackServices.valid = vm.openStackServices.checks.backup.status;
-                        // if the backup has finished set the step to complete
-                        if (vm.openStackServices.valid) {
-                            upgradeStepsFactory.setCurrentStepCompleted()
-                        }
-                    });
+        function stopServicesError(errorResponse) {
+            vm.checks.services.running = false;
+            vm.checks.services.completed = true
+            // Expose the error list to openStackServices object
+            vm.errors = errorResponse.data;
+        }
+
+        /**
+         * Trigger creation of OpenStack backup
+         */
+        function createBackup() {
+            if (vm.checks.backup.status) {
+                return;
             }
 
-            function stopServicesError (errorOpenStackServicesResponse) {
-                vm.openStackServices.completed = true;
-                vm.openStackServices.running = false;
-                // Expose the error list to openStackServices object
-                vm.openStackServices.errors = errorOpenStackServicesResponse.data.errors;
-            }
+            vm.checks.backup.completed = false;
+            vm.checks.backup.running = true;
 
-            function createBackupSuccess (openStackBackupResponse) {
-                vm.openStackServices.checks.backup.status = openStackBackupResponse.data.backup;
-            }
+            upgradeFactory.createOpenstackBackup()
+                .then(
+                    waitForBackupToEnd,
+                    createBackupError
+                );
+        }
 
-            function createBackupError (errorOpenStackServicesResponse) {
-                // Expose the error list to openStackServices object
-                vm.openStackServices.errors = errorOpenStackServicesResponse.data.errors;
-            }
+        /**
+         * Start polling for status and wait until backup is created
+         */
+        function waitForBackupToEnd() {
+            upgradeStatusFactory.waitForStepToEnd(
+                UPGRADE_STEPS.backup_openstack,
+                OPENSTACK_BACKUP_TIMEOUT_INTERVAL,
+                createBackupSuccess,
+                createBackupError
+            );
+        }
+
+        function createBackupSuccess(/*response*/) {
+            vm.checks.backup.running = false;
+            vm.checks.backup.status = true;
+            vm.checks.backup.completed = true;
+            upgradeStepsFactory.setCurrentStepCompleted()
+        }
+
+        function createBackupError(errorResponse) {
+            vm.checks.backup.running = false;
+            vm.checks.backup.status = false;
+            vm.checks.backup.completed = true;
+            // Expose the error list to openStackBackup object
+            vm.errors = errorResponse.data;
+        }
+
+        /**
+         * Start polling for status and wait until OpenStack services are stopped
+         */
+        function waitForStopServicesToEnd() {
+            upgradeStatusFactory.waitForStepToEnd(
+                UPGRADE_STEPS.services,
+                STOP_OPENSTACK_SERVICES_TIMEOUT_INTERVAL,
+                stopServicesSuccess,
+                function (errorResponse) {
+                    vm.checks.services.running = false;
+                    vm.checks.services.status = false;
+                    vm.checks.services.completed = true;
+                    vm.errors = errorResponse.data.steps.services;
+                }
+            );
         }
     }
 })();

--- a/assets/app/features/upgrade/templates/openstack-services.jade
+++ b/assets/app/features/upgrade/templates/openstack-services.jade
@@ -3,14 +3,15 @@ p(translate='') upgrade.steps.openstack-services.description
 
 button.btn.btn-success.center-block(
     ng-click='upgradeOpenStackServicesVm.openStackServices.stopServices()',
-    ng-disabled='(upgradeOpenStackServicesVm.openStackServices.completed && upgradeOpenStackServicesVm.openStackServices.valid) || upgradeOpenStackServicesVm.openStackServices.running',
+    ng-disabled='upgradeOpenStackServicesVm.checks.services.running || \
+        upgradeOpenStackServicesVm.checks.backup.completed || upgradeOpenStackServicesVm.checks.backup.running',
     ng-class='{\
         "spinner-visible": upgradeOpenStackServicesVm.openStackServices.spinnerVisible,\
-        active: upgradeOpenStackServicesVm.openStackServices.running\
+        active: upgradeOpenStackServicesVm.checks.services.running || upgradeOpenStackServicesVm.checks.backup.running \
     }',
 )
-    suse-lazy-spinner(delay='2000', active='upgradeOpenStackServicesVm.openStackServices.running',
+    suse-lazy-spinner(delay='2000', active='upgradeOpenStackServicesVm.checks.services.running || upgradeOpenStackServicesVm.checks.backup.running',
         visible='upgradeOpenStackServicesVm.openStackServices.spinnerVisible')
     span(translate='') upgrade.steps.openstack-services.form.stop-services
 
-crowbar-checklist(checklist='upgradeOpenStackServicesVm.openStackServices.checks', completed='upgradeOpenStackServicesVm.openStackServices.completed')
+crowbar-checklist(checklist='upgradeOpenStackServicesVm.checks')

--- a/assets/app/features/upgrade/upgrade.constants.js
+++ b/assets/app/features/upgrade/upgrade.constants.js
@@ -20,6 +20,8 @@
         .constant('ADMIN_UPGRADE_ALLOWED_DOWNTIME', 30 * 60 * 1000)
         .constant('ADMIN_UPGRADE_TIMEOUT_INTERVAL', 5000)
         .constant('NODES_UPGRADE_TIMEOUT_INTERVAL', 5000)
+        .constant('STOP_OPENSTACK_SERVICES_TIMEOUT_INTERVAL', 5000)
+        .constant('OPENSTACK_BACKUP_TIMEOUT_INTERVAL', 1000)
         .constant('UPGRADE_MODES', {
             nondisruptive: 'non-disruptive',
             disruptive: 'disruptive',


### PR DESCRIPTION
Complete implementation of stop-services page with async stopping of services and backup creation.
Major refactor compared to original implementation.