### PR TITLE
Update node's static state machine

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ var express = require('express'),
     logger = require('morgan'),
     cookieParser = require('cookie-parser'),
     bodyParser = require('body-parser'),
+    session = require('express-session'),
 
     //Routes
     index = require('./routes/index'),
@@ -22,6 +23,8 @@ var express = require('express'),
     utilsBackupDownload =  require('./routes/utils/backups/download'),
     nodesUpgrade = require('./routes/api/upgrade/nodes'),
 
+    upgradeSession = require('./helpers/upgradeSession'),
+
     app = express();
 
 // uncomment after placing your favicon in /public
@@ -30,24 +33,27 @@ app.use(logger('dev'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
+app.use(session({
+    secret: '1234567890QWERTY'
+}));
 app.use(express.static(path.join(__dirname, 'public')));
 
-app.use('/', index);
-app.use('/api/crowbar', crowbarEntity);
-app.use('/api/upgrade/adminrepocheck', crowbarRepocheck);
-app.use('/api/crowbar/upgrade', crowbarUpgrade);
-app.use('/api/upgrade', upgrade);
-app.use('/api/upgrade/prechecks', upgradePrechecks);
-app.use('/api/upgrade/noderepocheck', upgradeNodeRepocheck);
-app.use('/api/upgrade/prepare', upgradePrepare);
-app.use('/api/upgrade/new', upgradeNew);
-app.use('/api/upgrade/connect', upgradeConnect);
-app.use('/api/upgrade/cancel', upgradeCancel);
-app.use('/api/upgrade/services', upgradeServices);
-app.use('/api/openstack/backup', openstackBackup);
-app.use('/api/upgrade/adminbackup', utilsBackupCreate);
-app.use('/utils/backups/\*/download', utilsBackupDownload);
-app.use('/api/upgrade/nodes', nodesUpgrade);
+app.use('/', upgradeSession, index);
+app.use('/api/crowbar', upgradeSession, crowbarEntity);
+app.use('/api/upgrade/adminrepocheck', upgradeSession, crowbarRepocheck);
+app.use('/api/crowbar/upgrade', upgradeSession, crowbarUpgrade);
+app.use('/api/upgrade', upgradeSession, upgrade);
+app.use('/api/upgrade/prechecks', upgradeSession, upgradePrechecks);
+app.use('/api/upgrade/noderepocheck', upgradeSession, upgradeNodeRepocheck);
+app.use('/api/upgrade/prepare', upgradeSession, upgradePrepare);
+app.use('/api/upgrade/new', upgradeSession, upgradeNew);
+app.use('/api/upgrade/connect', upgradeSession, upgradeConnect);
+app.use('/api/upgrade/cancel', upgradeSession, upgradeCancel);
+app.use('/api/upgrade/services', upgradeSession, upgradeServices);
+app.use('/api/openstack/backup', upgradeSession, openstackBackup);
+app.use('/api/upgrade/adminbackup', upgradeSession, utilsBackupCreate);
+app.use('/utils/backups/\*/download', upgradeSession, utilsBackupDownload);
+app.use('/api/upgrade/nodes', upgradeSession, nodesUpgrade);
 
 
 

--- a/helpers/upgradeSession.js
+++ b/helpers/upgradeSession.js
@@ -1,0 +1,18 @@
+var express = require('express'),
+    router = express.Router(),
+    upgradeModel = require('./upgradeStatus.model');
+
+router.use(function (req, res, next) {
+    //console.log('Intercepting request: ' + req.path);
+    if (req.session.upgradeStatus) {
+        //console.log('========== Restoring Upgrade Status object');
+        upgradeModel.setStatus(req.session.upgradeStatus);
+    } else {
+        //console.log('++++++++++ New upgrade Status object created');
+        req.session.upgradeStatus = upgradeModel.getDefaultStatus();
+    }
+
+    next();
+});
+
+module.exports = router;

--- a/helpers/upgradeStatus.model.js
+++ b/helpers/upgradeStatus.model.js
@@ -1,4 +1,5 @@
 var express = require('express'),
+    totalNodes = 125,
     stepStatus = {
         pending: 'pending',
         running: 'running',
@@ -8,6 +9,7 @@ var express = require('express'),
     UpgradeStatusModel = {
         getStatus: getStatus,
         setStatus: setStatus,
+        setUpdatedNodes: setUpdatedNodes,
         getDefaultStatus: getDefaultStatus,
         getCurrentStep: getCurrentStep,
         getCurrentStepName: getCurrentStepName,
@@ -44,8 +46,8 @@ function getDefaultStatus() {
             role: 'controller',
             state: 'post-upgrade'
         },
-        remaining_nodes: 95,
-        upgraded_nodes: 60,
+        remaining_nodes: 125,
+        upgraded_nodes: 0,
         steps: {
             upgrade_prechecks: {
                 status: stepStatus.pending,
@@ -158,6 +160,18 @@ function getStatus () {
 
 function setStatus (upgradeStatus) {
     UpgradeStatusModel.status = upgradeStatus;
+}
+
+function setUpdatedNodes(updatedNodes) {
+    UpgradeStatusModel.status.upgraded_nodes = updatedNodes;
+    UpgradeStatusModel.status.remaining_nodes = totalNodes - updatedNodes;
+    UpgradeStatusModel.status.current_node = {
+        alias: 'controller-' + updatedNodes,
+        name: 'controller.' + updatedNodes + '.suse.com',
+        ip: updatedNodes + '.2.3.4',
+        role: 'controller: ' + updatedNodes,
+        state: 'post-upgrade: ' + updatedNodes
+    };
 }
 
 module.exports = UpgradeStatusModel;

--- a/helpers/upgradeStatus.model.js
+++ b/helpers/upgradeStatus.model.js
@@ -1,0 +1,163 @@
+var express = require('express'),
+    stepStatus = {
+        pending: 'pending',
+        running: 'running',
+        passed: 'passed',
+
+    },
+    UpgradeStatusModel = {
+        getStatus: getStatus,
+        setStatus: setStatus,
+        getDefaultStatus: getDefaultStatus,
+        getCurrentStep: getCurrentStep,
+        getCurrentStepName: getCurrentStepName,
+        completeCurrentStep: completeCurrentStep,
+        completeStep: completeStep,
+        runCurrentStep: runCurrentStep,
+        simulateDowntime: simulateDowntime,
+        status: getDefaultStatus()
+    };
+
+    const upgradeSteps = [
+        'upgrade_prechecks',
+        'upgrade_prepare',
+        'admin_backup',
+        'admin_repo_checks',
+        'admin_upgrade',
+        'database',
+        'nodes_repo_checks',
+        'nodes_services',
+        'nodes_db_dump',
+        'nodes_upgrade',
+        'finished'
+    ];
+
+// Define a basic model for the state
+function getDefaultStatus() {
+    return {
+        current_step: 'upgrade_prechecks',
+        substep: null,
+        current_node: {
+            alias: 'controller-1',
+            name: 'controller.1234.suse.com',
+            ip: '1.2.3.4',
+            role: 'controller',
+            state: 'post-upgrade'
+        },
+        remaining_nodes: 95,
+        upgraded_nodes: 60,
+        steps: {
+            upgrade_prechecks: {
+                status: stepStatus.pending,
+                errors: {}
+            },
+            upgrade_prepare: {
+                status: stepStatus.pending,
+                errors: {}
+            },
+            admin_backup: {
+                status: stepStatus.pending,
+                errors: {}
+            },
+            admin_repo_checks: {
+                status: stepStatus.pending,
+                errors: {}
+            },
+            admin_upgrade: {
+                status: stepStatus.pending,
+                errors: {}
+            },
+            database: {
+                status: stepStatus.pending,
+                errors: {}
+            },
+            nodes_repo_checks: {
+                status: stepStatus.pending,
+                errors: {}
+            },
+            nodes_services: {
+                status: stepStatus.pending,
+                errors: {}
+            },
+            nodes_db_dump: {
+                status: stepStatus.pending,
+                errors: {}
+            },
+            nodes_upgrade: {
+                status: stepStatus.pending,
+                errors: {}
+            },
+            finished: {
+                status: stepStatus.pending,
+                errors: {}
+            }
+        }
+    };
+}
+
+function runCurrentStep () {
+    var currentStepName = UpgradeStatusModel.status.current_step,
+        currentStepIndex = upgradeSteps.indexOf(currentStepName);
+
+    // Complete previous steps, if any
+    if (currentStepIndex > 1) {
+        completeStep(upgradeSteps[currentStepIndex - 1]);
+    }
+
+    // Set current step status to running
+    UpgradeStatusModel.status.steps[currentStepName].status = stepStatus.running;
+}
+
+function completeCurrentStep () {
+
+    var currentStepName = UpgradeStatusModel.status.current_step;
+    console.log('Complete current step: ' + currentStepName);
+
+    // Complete the current step
+    completeStep(currentStepName);
+}
+
+function completeStep (stepName) {
+    var stepIndex = upgradeSteps.indexOf(stepName);
+
+    // Complete the steps until the current one
+    for (var i = 0; i < stepIndex; i++) {
+        console.log('Setting as passed:' + upgradeSteps[i]);
+        UpgradeStatusModel.status.steps[upgradeSteps[i]].status = stepStatus.passed
+    }
+    UpgradeStatusModel.status.steps[stepName].status = stepStatus.passed;
+    console.log('Step: %s - Status: %s', stepName, UpgradeStatusModel.status.steps[stepName].status);
+    // Set current_step to the next step
+    UpgradeStatusModel.status.current_step = upgradeSteps[stepIndex + 1];
+    console.log('---- New Current Step: %s - Status: %s', UpgradeStatusModel.getCurrentStepName(), UpgradeStatusModel.getCurrentStep().status);
+}
+
+function simulateDowntime () {
+    var currentStepName = UpgradeStatusModel.status.current_step,
+        currentStepIndex = upgradeSteps.indexOf(currentStepName);
+
+    // nullify the current step to simulate failure
+    UpgradeStatusModel.status.steps[currentStepName].status = null;
+}
+
+function getCurrentStep () {
+    var currentStepName = UpgradeStatusModel.status.current_step,
+        currentStepIndex = upgradeSteps.indexOf(currentStepName);
+
+    // Complete the current step
+    return UpgradeStatusModel.status.steps[currentStepName];
+}
+
+function getCurrentStepName () {
+    return UpgradeStatusModel.status.current_step;
+}
+
+function getStatus () {
+    return UpgradeStatusModel.status;
+}
+
+function setStatus (upgradeStatus) {
+    UpgradeStatusModel.status = upgradeStatus;
+}
+
+module.exports = UpgradeStatusModel;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "body-parser": "~1.13.2",
     "cookie-parser": "~1.3.5",
     "express": "~4.13.1",
+    "express-session": "^1.14.2",
     "jade": "~1.11.0",
     "main-bower-files": "^2.13.1",
     "mime": "^1.3.4",

--- a/routes/api/crowbar/upgrade.js
+++ b/routes/api/crowbar/upgrade.js
@@ -1,5 +1,6 @@
 var express = require('express'),
-    router = express.Router();
+    router = express.Router(),
+    upgradeModel = require('../../../helpers/upgradeStatus.model');
 
 var errors = ['001', '002', '003'];
 var upgrading_state = -1;
@@ -10,6 +11,10 @@ router.post('/', function(req, res) {
     if('fail' in req.query && JSON.parse(req.query.fail) === true) {
         res.status(500).json({'errors': errors});
     } else {
+
+        upgradeModel.runCurrentStep();
+        req.session.upgradeStatus = upgradeModel.getStatus();
+
         res.status(200).json({
             version: '3.0',
             addons: [],

--- a/routes/api/openstack/backup.js
+++ b/routes/api/openstack/backup.js
@@ -1,15 +1,28 @@
 var express = require('express'),
     router = express.Router(),
-    callNumber = -1;
+    callNumber = -1,
+    upgradeModel = require('../../../helpers/upgradeStatus.model');
 
 /* POST openStack services Checks. */
 router.post('/', function(req, res) {
     callNumber += 1;
     if (callNumber > 0) {
+
+        if (upgradeModel.getCurrentStepName() === 'nodes_db_dump') {
+            upgradeModel.completeCurrentStep();
+            req.session.upgradeStatus = upgradeModel.getStatus();
+        }
+
         res.status(200).json({
             backup: true
         });
     } else {
+
+        if (upgradeModel.getCurrentStepName() === 'nodes_db_dump') {
+            upgradeModel.runCurrentStep();
+            req.session.upgradeStatus = upgradeModel.getStatus();
+        }
+
         res.status(422).json({
             msg: 'failure message'
         });

--- a/routes/api/upgrade.js
+++ b/routes/api/upgrade.js
@@ -18,6 +18,11 @@ var stepStatus = {
 /* GET upgrade status. */
 router.get('/', function(req, res) {
 
+    if (upgradeModel.getCurrentStepName() === 'nodes_upgrade' &&
+        upgradeModel.getCurrentStep().status === stepStatus.running) {
+        upgradeModel.setUpdatedNodes(status_counter * 25);
+    }
+
     if (upgradeModel.getCurrentStep().status === null ||
         upgradeModel.getCurrentStep().status === stepStatus.running
     ) {

--- a/routes/api/upgrade/adminrepocheck.js
+++ b/routes/api/upgrade/adminrepocheck.js
@@ -1,6 +1,7 @@
 var express = require('express'),
     router = express.Router(),
-    repo_correct = false;
+    repo_correct = false,
+    upgradeModel = require('../../../helpers/upgradeStatus.model');
 
 /* GET Admin Repo Checks. */
 router.get('/', function(req, res) {
@@ -27,6 +28,9 @@ router.get('/', function(req, res) {
             'available': true,
             'repos': {}
         }
+
+        upgradeModel.completeCurrentStep();
+        req.session.upgradeStatus = upgradeModel.getStatus();
     }
     repo_correct = !repo_correct;
     res.status(200).json(data);

--- a/routes/api/upgrade/cancel.js
+++ b/routes/api/upgrade/cancel.js
@@ -3,6 +3,8 @@ var express = require('express'),
 
 /* cancel upgrade. */
 router.post('/', function(req, res) {
+    //Destroy the current session.
+    req.session.destroy();
     res.status(200).end();
 });
 

--- a/routes/api/upgrade/connect.js
+++ b/routes/api/upgrade/connect.js
@@ -1,5 +1,6 @@
 var express = require('express'),
     router = express.Router(),
+    upgradeModel = require('../../../helpers/upgradeStatus.model'),
     responseOk = {
         'database_setup': {
             'success': true
@@ -60,7 +61,15 @@ router.post('/', function(req, res) {
             res.status(406).json(responseFailDatabase);
         }, 4000);
     } else {
+
+        upgradeModel.runCurrentStep();
+        req.session.upgradeStatus = upgradeModel.getStatus();
+
         setTimeout(function () {
+
+            upgradeModel.completeCurrentStep();
+            req.session.upgradeStatus = upgradeModel.getStatus();
+
             res.status(200).json(responseOk);
         }, 4000);
     }

--- a/routes/api/upgrade/new.js
+++ b/routes/api/upgrade/new.js
@@ -1,5 +1,6 @@
 var express = require('express'),
-    router = express.Router();
+    router = express.Router(),
+    upgradeModel = require('../../../helpers/upgradeStatus.model');
 
 var responseOk = {
         'database_setup': {
@@ -40,7 +41,15 @@ router.post('/', function(req, res) {
             res.status(422).json(responseFail)
         }, 4000)
     } else {
+
+        upgradeModel.runCurrentStep();
+        req.session.upgradeStatus = upgradeModel.getStatus();
+
         setTimeout(function () {
+
+            upgradeModel.completeCurrentStep();
+            req.session.upgradeStatus = upgradeModel.getStatus();
+
             res.status(200).json(responseOk)
         }, 4000);
     }

--- a/routes/api/upgrade/noderepocheck.js
+++ b/routes/api/upgrade/noderepocheck.js
@@ -1,8 +1,13 @@
 var express = require('express'),
-    router = express.Router();
+    router = express.Router(),
+    upgradeModel = require('../../../helpers/upgradeStatus.model');
 
 /* GET Nodes Repo Checks. */
 router.get('/', function(req, res) {
+
+    upgradeModel.completeCurrentStep();
+    req.session.upgradeStatus = upgradeModel.getStatus();
+
     res.status(200).json({
         'ceph': {
             'available': true,

--- a/routes/api/upgrade/nodes.js
+++ b/routes/api/upgrade/nodes.js
@@ -1,8 +1,13 @@
 var express = require('express'),
-    router = express.Router();
+    router = express.Router(),
+    upgradeModel = require('../../../helpers/upgradeStatus.model');
 
 /* nodes upgrade. */
 router.post('/', function(req, res) {
+
+    upgradeModel.runCurrentStep();
+    req.session.upgradeStatus = upgradeModel.getStatus();
+
     res.status(200).end();
 });
 

--- a/routes/api/upgrade/prechecks.js
+++ b/routes/api/upgrade/prechecks.js
@@ -1,5 +1,6 @@
 var express = require('express'),
-    router = express.Router();
+    router = express.Router(),
+    upgradeModel = require('../../../helpers/upgradeStatus.model');
 
 var errors = ['001', '002', '003'],
     checksPass = false,
@@ -10,6 +11,10 @@ router.get('/', function(req, res) {
     if('fail' in req.query && JSON.parse(req.query.fail) === true) {
         res.status(500).json({'errors': errors});
     } else {
+        if (upgradeModel.getCurrentStepName() === 'upgrade_prechecks') {
+            upgradeModel.completeCurrentStep();
+            req.session.upgradeStatus = upgradeModel.getStatus();
+        }
         // fail some checks first, then succeed on second call
         res.status(200).json({
             'checks': {

--- a/routes/api/upgrade/prepare.js
+++ b/routes/api/upgrade/prepare.js
@@ -1,5 +1,6 @@
 var express = require('express'),
-    router = express.Router();
+    router = express.Router(),
+    upgradeModel = require('../../../helpers/upgradeStatus.model');
 
 var errors = ['001', '002', '003'];
 
@@ -8,6 +9,8 @@ router.post('/', function(req, res) {
     if('fail' in req.query && JSON.parse(req.query.fail) === true) {
         res.status(500).json({'errors': errors});
     } else {
+        upgradeModel.completeCurrentStep();
+        req.session.upgradeStatus = upgradeModel.getStatus();
         res.status(200).end();
     }
 });

--- a/routes/api/upgrade/services.js
+++ b/routes/api/upgrade/services.js
@@ -1,12 +1,26 @@
 var express = require('express'),
     router = express.Router(),
-    callNumber = -1;
+    callNumber = -1,
+    upgradeModel = require('../../../helpers/upgradeStatus.model');
 
 /* POST openStack services Checks. */
 router.post('/', function(req, res) {
     callNumber += 1;
     if (callNumber > 0) {
+
+        if (upgradeModel.getCurrentStepName() === 'nodes_services') {
+            //Set current state as Run and save to session
+            upgradeModel.runCurrentStep();
+            req.session.upgradeStatus = upgradeModel.getStatus();
+        }
         setTimeout(function () {
+
+            if (upgradeModel.getCurrentStepName() === 'nodes_services') {
+                //Complete current state and save to session
+                upgradeModel.completeCurrentStep();
+                req.session.upgradeStatus = upgradeModel.getStatus();
+            }
+
             res.status(200).send();
         }, 3000)
     } else {

--- a/routes/utils/backups/download.js
+++ b/routes/utils/backups/download.js
@@ -2,9 +2,13 @@ var express = require('express'),
     router = express.Router(),
     path = require('path'),
     mime = require('mime'),
-    fs = require('fs');
+    fs = require('fs'),
+    upgradeModel = require('../../../helpers/upgradeStatus.model');
 
 router.get('/', function(req, res) {
+
+    upgradeModel.completeCurrentStep();
+    req.session.upgradeStatus = upgradeModel.getStatus();
 
     var file = __dirname + '/1.zip',
         filename = path.basename(file),
@@ -15,6 +19,7 @@ router.get('/', function(req, res) {
     res.setHeader('Content-type', mimetype);
 
     filestream.pipe(res);
+
 });
 
 module.exports = router;


### PR DESCRIPTION
Add session to static service in order to simulate each steps and status.
Missing: nodes_upgrade progress (`current_node`, `remaining_nodes` and `upgraded_nodes`)

Failing unit tests needs to be fixed (and merged/rebased) from https://github.com/crowbar/crowbar-ui/pull/108