### PR TITLE
upgrade: Stop waiting on failed step

### DIFF
--- a/assets/app/data/crowbar/services/upgrade-status.factory.js
+++ b/assets/app/data/crowbar/services/upgrade-status.factory.js
@@ -65,9 +65,13 @@
             upgradeFactory.getStatus()
                 .then(
                     function (response) {
+                        var stepStatus = response.data.steps[step].status;
                         // If the step is completed, trigger its success handler
-                        if (response.data.steps[step].status === UPGRADE_STEP_STATES.passed) {
+                        if (stepStatus === UPGRADE_STEP_STATES.passed) {
                             onSuccess(response);
+                        } else if (stepStatus === UPGRADE_STEP_STATES.failed) {
+                            // on step failure trigger error handler
+                            onError(response);
                         } else {
 
                             // If the response needs to be processed before the step if completed


### PR DESCRIPTION
Status API returns success HTTP code when current step has failed.
The actual status inside response needs to be checked to handle
such cases properly.
If that happens `onError` callback is triggered with the whole
response received from the API. Status code and response content
can be used to distinguish between different error cases.

BONUS: the tests were cleaned up a bit