### PR TITLE
upgrade: Translate names of failing prechecks

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
@@ -186,7 +186,11 @@
                             updateMode();
                         } else {
                             // TODO(itxaka): This is a tmp thing, should be clarified
-                            vm.error = {title: 'Some checks failed', body: checksErrors.join()};
+                            var failedCheckLabels = [];
+                            _.forEach(checksErrors, function (code) {
+                                failedCheckLabels.push($translate.instant(vm.prechecks.checks[code].label));
+                            });
+                            vm.error = {title: 'Some checks failed', body: failedCheckLabels.join(', ')};
                         }
                     },
                     //Failure handler:

--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
@@ -182,6 +182,9 @@ describe('Upgrade Landing Controller', function() {
         };
 
     beforeEach(function() {
+        // load ngSanitize to make translations happy
+        module('ngSanitize');
+
         //Setup the module and dependencies to be used.
         bard.appModule('crowbarApp.upgrade');
         bard.inject('$controller', '$rootScope', 'upgradeFactory',


### PR DESCRIPTION
The failing prechecks are code-named in the error message displayed
to the user. This change passes them through $translate service.

**NOTE:**
The $translate service is async now (see: https://angular-translate.github.io/docs/#/guide/03_using-translate-service) but I think in our case we can stick with the sync calls to make things easier as we don't change translations after application is started.