### PR TITLE
upgrade: Admin Server Backup error handling

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-backup.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-backup.controller.js
@@ -20,6 +20,7 @@ function() {
         'upgradeStepsFactory',
         'upgradeFactory',
         'FileSaver',
+        'UNEXPECTED_ERROR_DATA',
     ];
     // @ngInject
     function UpgradeBackupController(
@@ -29,7 +30,8 @@ function() {
         $document,
         upgradeStepsFactory,
         upgradeFactory,
-        FileSaver
+        FileSaver,
+        UNEXPECTED_ERROR_DATA
     ) {
         var vm = this;
         vm.backup = {
@@ -51,9 +53,12 @@ function() {
                     },
                     // In case of backup error
                     function (errorResponse) {
-                        vm.backup.errors = errorResponse.data.errors;
+                        if (angular.isDefined(errorResponse.data.errors)) {
+                            vm.backup.errors = errorResponse.data;
+                        } else {
+                            vm.backup.errors = UNEXPECTED_ERROR_DATA;
+                        }
                         vm.backup.running = false;
-                        vm.backup.completed = true;
                     }
                 );
         }
@@ -82,16 +87,21 @@ function() {
                             filename = extractFilename(headers) || 'crowbarBackup';
 
                         FileSaver.saveAs(response.data, filename)
+
+                        upgradeStepsFactory.setCurrentStepCompleted()
+                        vm.backup.completed = true;
                     },
                     // In case of download error
                     function (errorResponse) {
-                        vm.backup.errors = errorResponse.data.errors;
+                        if (angular.isDefined(errorResponse.data.errors)) {
+                            vm.backup.errors = errorResponse.data;
+                        } else {
+                            vm.backup.errors = UNEXPECTED_ERROR_DATA;
+                        }
                     }
                 )
                 .finally(function () {
                     vm.backup.running = false;
-                    vm.backup.completed = true;
-                    upgradeStepsFactory.setCurrentStepCompleted()
                 });
         }
 

--- a/assets/app/features/upgrade/controllers/upgrade-backup.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-backup.controller.spec.js
@@ -85,8 +85,12 @@ describe('Upgrade Flow - Backup Controller', function() {
                     expect(controller.backup.download).toHaveBeenCalled();
                 });
 
-                it('should set running to true', function () {
+                it('should leave running at true', function () {
                     assert.isTrue(controller.backup.running);
+                });
+
+                it('should not set completed to true', function () {
+                    assert.isFalse(controller.backup.completed);
                 });
             });
 
@@ -110,7 +114,7 @@ describe('Upgrade Flow - Backup Controller', function() {
                 });
 
                 it('should expose the errors through adminUpgrade.errors object', function () {
-                    expect(controller.backup.errors).toEqual(mockedErrorList);
+                    expect(controller.backup.errors.errors).toEqual(mockedErrorList);
                 });
             });
         });
@@ -216,12 +220,12 @@ describe('Upgrade Flow - Backup Controller', function() {
                         assert.isTrue(crowbarUtilsFactory.getAdminBackup.calledOnce);
                     });
 
-                    it('changes the completed status', function() {
-                        assert.isTrue(controller.backup.completed);
+                    it('leaves the completed at false', function() {
+                        assert.isFalse(controller.backup.completed);
                     });
 
                     it('should expose the errors through adminUpgrade.errors object', function () {
-                        expect(controller.backup.errors).toEqual(mockedErrorList);
+                        expect(controller.backup.errors.errors).toEqual(mockedErrorList);
                     });
                 });
 

--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -151,7 +151,9 @@
             "prechecks": "Some Checks failed",
             "maintenance_updates_installed": "Maintenance Updates",
             "clusters_health_crm_failures": "Some crm commands failed",
-            "clusters_health_failed_actions": "Some Clusters Health actions have failed"
+            "clusters_health_failed_actions": "Some Clusters Health actions have failed",
+            "unexpected_error": "Unexpected Error",
+            "admin_backup": "Administration Server Backup Failed"
         }
     },
     "footer": {

--- a/assets/app/features/upgrade/templates/backup-page.jade
+++ b/assets/app/features/upgrade/templates/backup-page.jade
@@ -11,3 +11,4 @@ button.btn.btn-primary.center-block(
   suse-lazy-spinner(delay="2000", active="upgradeBackupVm.backup.running",
     visible="upgradeBackupVm.backup.spinnerVisible")
   span(translate='') upgrade.steps.backup.form.backup
+suse-modal(error="upgradeBackupVm.backup.errors", translation-prefix="upgrade.errors")


### PR DESCRIPTION
Added catching of all backend errors on the backup page.
50x errors are shown with a common pre-defined message as they
don't contain any useful information in the response.