### PR TITLE
upgrade: Error modal common format

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
@@ -491,7 +491,7 @@ describe('Upgrade Landing Controller', function() {
                 });
 
                 it('should expose the errors through vm.prechecks.errors object', function () {
-                    expect(controller.prechecks.errors).toEqual(failingResponse.data.errors);
+                    expect(controller.errors).toEqual(failingResponse.data);
                 });
             });
         });

--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -147,6 +147,7 @@
             }
         },
         "errors": {
+            "default-title": "Upgrade Error"
         }
     },
     "footer": {
@@ -156,6 +157,7 @@
         "title": "SUSE OpenStack Cloud: Upgrade 6-7"
     },
     "modal": {
-        "close": "Close"
+        "close": "Close",
+        "default-title": "Error"
     }
 }

--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -147,7 +147,11 @@
             }
         },
         "errors": {
-            "default-title": "Upgrade Error"
+            "default-title": "Upgrade Error",
+            "prechecks": "Some Checks failed",
+            "maintenance_updates_installed": "Maintenance Updates",
+            "clusters_health_crm_failures": "Some crm commands failed",
+            "clusters_health_failed_actions": "Some Clusters Health actions have failed"
         }
     },
     "footer": {

--- a/assets/app/features/upgrade/templates/landing-page.jade
+++ b/assets/app/features/upgrade/templates/landing-page.jade
@@ -11,4 +11,4 @@
     .row.hidden-md.hidden-lg.step-3(ng-class="{'enabled': upgradeLandingVm.mode.valid}")
         .col-md-6
             include landing-page_step3.partial.jade
-suse-modal(error="upgradeLandingVm.error", translation-prefix="upgrade.errors")
+suse-modal(error="upgradeLandingVm.errors", translation-prefix="upgrade.errors")

--- a/assets/app/features/upgrade/templates/landing-page.jade
+++ b/assets/app/features/upgrade/templates/landing-page.jade
@@ -11,4 +11,4 @@
     .row.hidden-md.hidden-lg.step-3(ng-class="{'enabled': upgradeLandingVm.mode.valid}")
         .col-md-6
             include landing-page_step3.partial.jade
-suse-modal(error="upgradeLandingVm.error")
+suse-modal(error="upgradeLandingVm.error", translation-prefix="upgrade.errors")

--- a/assets/app/features/upgrade/upgrade.constants.js
+++ b/assets/app/features/upgrade/upgrade.constants.js
@@ -12,6 +12,15 @@
             'ha': ['clusters_healthy'],
             'ceph': ['ceph_healthy']
         })
+        .constant('UNEXPECTED_ERROR_DATA', {
+            title: 'unexpected_error',
+            errors: {
+                unexpected_error: {
+                    data: 'An unexpected error ocurred',
+                    help: 'Please check logs for more details'
+                }
+            }
+        })
         .constant('UPGRADE_LAST_STATE_KEY', 'crowbar.upgrade.lastUIState')
         .constant('PREPARE_TIMEOUT_INTERVAL', 1000)
         .constant('ADMIN_UPGRADE_ALLOWED_DOWNTIME', 30 * 60 * 1000)

--- a/assets/app/widgets/suse-modal/suse-modal.directive.jade
+++ b/assets/app/widgets/suse-modal/suse-modal.directive.jade
@@ -2,9 +2,14 @@
     .modal-header
         button.close(type='button', ng-click='dismiss()', aria-label='Close')
             span(aria-hidden='true') ×
-        h4.modal-title {{ error.title }}
+        h4.modal-title(ng-if='error.title') {{ (translationPrefix + '.' + error.title) | translate }}
+        h4.modal-title(ng-if='!error.title') {{ (translationPrefix + '.default-title') | translate }}
     .modal-body
-        p {{ error.body }}
+        div.panel.panel-danger(ng-repeat="(code, data) in error.errors")
+            div.panel-heading {{ (translationPrefix + '.' + code) | translate }}
+            div.panel-body
+                p {{ data.data }}
+                p {{ data.help }}
     .modal-footer
         button.btn.btn-default(type='button', ng-click='dismiss()')
             span(translate='') modal.close

--- a/assets/app/widgets/suse-modal/suse-modal.directive.js
+++ b/assets/app/widgets/suse-modal/suse-modal.directive.js
@@ -19,15 +19,22 @@
         return {
             restrict: 'E',
             scope: {
-                error: '='
+                error: '=',
+                translationPrefix: '@',
             },
             link: function (scope) {
+                // init optional binding values
+                scope.translationPrefix = scope.translationPrefix || 'modal';
+
                 scope.$watch('error', function(value) {
                     if (angular.isDefined(value)) {
                         $uibModal.open({
                             templateUrl: 'app/widgets/suse-modal/suse-modal.directive.html',
                             controller: modalController,
                             scope: scope
+                        }).closed.then(function () {
+                            // clear the errors when window is closed
+                            scope.error = undefined;
                         });
 
                     }


### PR DESCRIPTION
The error modal was modified to accept errors in common format returned from the API.
Landing page was updated to match this.

Errors passed to modal should be defined in following format:
```
errors = {
  title: "optional_title_code",
  errors: {
    error_code1: { data: [ 1, 2, 3 ], help: "some help text" },
    error_code2: { data: "cmd output text", help: "fix the problem" }
  }
}
```
All error codes and title are translated and scoped using `translation-prefix` directive attribute (default: `modal`).
All upgrade related error codes and messages should be placed in `upgrade.errors` sections of the language file.
If title is omitted, `default-title` code is used (with scoping prefix added).

For simple errors returned from the backend, this leads to basic implementation:
```
errors = response.data;
```
