### PR TITLE
upgrade: Fixed typo in Stop Services UI

### DIFF
--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -119,7 +119,7 @@
                     "backup" : "Backup Created"
                 },
                 "form": {
-                    "stop-services": "Stop OpenStack Servers"
+                    "stop-services": "Stop OpenStack Services"
                 }
             },
             "upgrade-nodes": {


### PR DESCRIPTION
The button said "Servers" instead of "Services". There are no servers
stopped during this step, just services.