### PR TITLE
upgrade: Fix style of disabled tab

### DIFF
--- a/assets/app/features/upgrade/templates/database-configuration-page.less
+++ b/assets/app/features/upgrade/templates/database-configuration-page.less
@@ -10,6 +10,10 @@
         &.active > a {
             color: @active-nav-tab-fg;
         }
+
+        &.disabled > a {
+            color: @disabled-nav-tab-fg;
+        }
     }
 
     .tab-content {

--- a/assets/content/less/variables.less
+++ b/assets/content/less/variables.less
@@ -20,5 +20,6 @@
 
 @nav-tab-fg: #488fcc;;
 @active-nav-tab-fg: #3f4345;
+@disabled-nav-tab-fg: #777;
 
 /* End= variables.less */


### PR DESCRIPTION
After database configuration is done, tabs in the UI are disabled
but out styles override default "disabled" look. This change adds
custom style for disabled tabs to restore the default look.