### PR TITLE
upgrade: Backend repo mapping for repochecks

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.js
@@ -17,7 +17,7 @@
     ];
     // @ngInject
     function UpgradeAdministrationRepositoriesCheckController(
-        $translate, upgradeFactory, upgradeStepsFactorym, UNEXPECTED_ERROR_DATA
+        $translate, upgradeFactory, upgradeStepsFactory, UNEXPECTED_ERROR_DATA
     ) {
         var vm = this;
         vm.repoChecks = {

--- a/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.js
@@ -13,11 +13,11 @@
             UpgradeAdministrationRepositoriesCheckController);
 
     UpgradeAdministrationRepositoriesCheckController.$inject = [
-        '$translate', 'upgradeFactory', 'PRODUCTS_REPO_CHECKS_MAP', 'upgradeStepsFactory', 'UNEXPECTED_ERROR_DATA'
+        '$translate', 'upgradeFactory', 'upgradeStepsFactory', 'UNEXPECTED_ERROR_DATA'
     ];
     // @ngInject
     function UpgradeAdministrationRepositoriesCheckController(
-        $translate, upgradeFactory, PRODUCTS_REPO_CHECKS_MAP, upgradeStepsFactory, UNEXPECTED_ERROR_DATA
+        $translate, upgradeFactory, upgradeStepsFactorym, UNEXPECTED_ERROR_DATA
     ) {
         var vm = this;
         vm.repoChecks = {
@@ -58,13 +58,12 @@
                     function (repoChecksResponse) {
                         var repoErrors = [];
                         // Iterate over our map
-                        _.forEach(PRODUCTS_REPO_CHECKS_MAP, function (repos, type) {
-                            // Admin repochecks only checks for os or openstack repos
-                            if(type == 'os' || type == 'openstack') {
-                                _.forEach(repos, function(repo) {
-                                    vm.repoChecks.checks[repo].status = repoChecksResponse.data[type].available
-                                });
-                            }
+                        _.forEach(repoChecksResponse.data, function (productData/*, product*/) {
+                            _.forEach(productData.repos, function(repo) {
+                                if (vm.repoChecks.checks.hasOwnProperty(repo)) {
+                                    vm.repoChecks.checks[repo].status = productData.available
+                                }
+                            });
                         });
                         // Iterate over the checks to determine the validity of the step
                         vm.repoChecks.valid = Object.keys(vm.repoChecks.checks).every(function(k) {

--- a/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.spec.js
@@ -8,7 +8,7 @@ describe('Upgrade Flow - Admin Repositories Checks Controller', function () {
             },
             openstack: {
                 available: true,
-                repos: ['Cloud', 'SUSE-OpenStack-Cloud-7-Pool', 'SUSE-OpenStack-Cloud-7-Updates'],
+                repos: ['SUSE-OpenStack-Cloud-7-Pool', 'SUSE-OpenStack-Cloud-7-Updates'],
             }
         },
         failingRepoChecks = {
@@ -18,7 +18,7 @@ describe('Upgrade Flow - Admin Repositories Checks Controller', function () {
             },
             openstack: {
                 available: false,
-                repos: ['Cloud', 'SUSE-OpenStack-Cloud-7-Pool', 'SUSE-OpenStack-Cloud-7-Updates'],
+                repos: ['SUSE-OpenStack-Cloud-7-Pool', 'SUSE-OpenStack-Cloud-7-Updates'],
             }
         },
         partiallyFailingRepoChecks = {
@@ -28,7 +28,7 @@ describe('Upgrade Flow - Admin Repositories Checks Controller', function () {
             },
             openstack: {
                 available: false,
-                repos: ['Cloud', 'SUSE-OpenStack-Cloud-7-Pool', 'SUSE-OpenStack-Cloud-7-Updates'],
+                repos: ['SUSE-OpenStack-Cloud-7-Pool', 'SUSE-OpenStack-Cloud-7-Updates'],
             }
         },
         failingErrors = {

--- a/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.spec.js
@@ -1,28 +1,34 @@
-/*global module bard $controller $httpBackend should assert upgradeFactory $q $rootScope PRODUCTS_REPO_CHECKS_MAP*/
+/*global module bard $controller $httpBackend should assert upgradeFactory $q $rootScope*/
 describe('Upgrade Flow - Admin Repositories Checks Controller', function () {
     var controller,
         passingRepoChecks = {
             os: {
-                available: true
+                available: true,
+                repos: ['SLES12-SP2-Pool', 'SLES12-SP2-Updates'],
             },
             openstack: {
-                available: true
+                available: true,
+                repos: ['Cloud', 'SUSE-OpenStack-Cloud-7-Pool', 'SUSE-OpenStack-Cloud-7-Updates'],
             }
         },
         failingRepoChecks = {
             os: {
-                available: false
+                available: false,
+                repos: ['SLES12-SP2-Pool', 'SLES12-SP2-Updates'],
             },
             openstack: {
-                available: false
+                available: false,
+                repos: ['Cloud', 'SUSE-OpenStack-Cloud-7-Pool', 'SUSE-OpenStack-Cloud-7-Updates'],
             }
         },
         partiallyFailingRepoChecks = {
             os: {
-                available: true
+                available: true,
+                repos: ['SLES12-SP2-Pool', 'SLES12-SP2-Updates'],
             },
             openstack: {
-                available: false
+                available: false,
+                repos: ['Cloud', 'SUSE-OpenStack-Cloud-7-Pool', 'SUSE-OpenStack-Cloud-7-Updates'],
             }
         },
         failingErrors = {
@@ -53,7 +59,7 @@ describe('Upgrade Flow - Admin Repositories Checks Controller', function () {
         bard.appModule('crowbarApp.upgrade');
         bard.inject(
             '$controller', 'upgradeFactory', '$q', '$httpBackend',
-            '$rootScope', 'PRODUCTS_REPO_CHECKS_MAP'
+            '$rootScope'
         );
 
         //Create the controller
@@ -177,14 +183,13 @@ describe('Upgrade Flow - Admin Repositories Checks Controller', function () {
 
             it('should update checks values to true or false as per the response', function () {
                 assert.isObject(controller.repoChecks.checks);
-                _.forEach(PRODUCTS_REPO_CHECKS_MAP, function(repos, type) {
-                    // Admin repochecks only checks for os or openstack repos
-                    if (type == 'os' || type == 'openstack') {
-                        _.forEach(repos, function (repo) {
+                _.forEach(partiallyFailingChecksResponse.data, function(productData, product) {
+                    _.forEach(productData.repos, function (repo) {
+                        if (controller.repoChecks.checks.hasOwnProperty(repo)) {
                             expect(controller.repoChecks.checks[repo].status)
-                                .toEqual(partiallyFailingChecksResponse.data[type].available)
-                        });
-                    }
+                                .toEqual(partiallyFailingChecksResponse.data[product].available)
+                        }
+                    });
                 });
             });
         });

--- a/assets/app/features/upgrade/controllers/upgrade-nodes-repositories-checks.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-nodes-repositories-checks.controller.spec.js
@@ -4,7 +4,11 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
         failingRepoChecks = {
             'ceph': {
                 'available': false,
-                'repos': {
+                'repos': [
+                    'SUSE-Enterprise-Storage-4-Pool',
+                    'SUSE-Enterprise-Storage-4-Updates'
+                ],
+                'errors': {
                     'missing': {
                         'x86_64': [
                             'SUSE-Enterprise-Storage-4-Pool',
@@ -21,7 +25,11 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             },
             'ha': {
                 'available': false,
-                'repos': {
+                'repos': [
+                    'SLE12-SP2-HA-Pool',
+                    'SLE12-SP2-HA-Updates'
+                ],
+                'errors': {
                     'missing': {
                         'x86_64': [
                             'SLE12-SP2-HA-Pool',
@@ -38,7 +46,11 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             },
             'os': {
                 'available': false,
-                'repos': {
+                'repos': [
+                    'SLES12-SP2-Pool',
+                    'SLES12-SP2-Updates'
+                ],
+                'errors': {
                     'missing': {
                         'x86_64': [
                             'SLES12-SP2-Pool',
@@ -55,7 +67,11 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             },
             'openstack': {
                 'available': false,
-                'repos': {
+                'repos': [
+                    'SUSE-OpenStack-Cloud-7-Pool',
+                    'SUSE-OpenStack-Cloud-7-Updates'
+                ],
+                'errors': {
                     'missing': {
                         'x86_64': [
                             'SUSE-OpenStack-Cloud-7-Pool',
@@ -74,25 +90,45 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
         passingRepoChecks = {
             'ceph': {
                 'available': true,
-                'repos': {}
+                'repos': [
+                    'SUSE-Enterprise-Storage-4-Pool',
+                    'SUSE-Enterprise-Storage-4-Updates'
+                ],
+                'errors': {}
             },
             'ha': {
                 'available': true,
-                'repos': {}
+                'repos': [
+                    'SLE12-SP2-HA-Pool',
+                    'SLE12-SP2-HA-Updates'
+                ],
+                'errors': {}
             },
             'os': {
                 'available': true,
-                'repos': {}
+                'repos': [
+                    'SLES12-SP2-Pool',
+                    'SLES12-SP2-Updates'
+                ],
+                'errors': {}
             },
             'openstack': {
                 'available': true,
-                'repos': {}
+                'repos': [
+                    'SUSE-OpenStack-Cloud-7-Pool',
+                    'SUSE-OpenStack-Cloud-7-Updates'
+                ],
+                'errors': {}
             }
         },
         partiallyFailingRepoChecks = {
             'ceph': {
                 'available': false,
-                'repos': {
+                'repos': [
+                    'SUSE-Enterprise-Storage-4-Pool',
+                    'SUSE-Enterprise-Storage-4-Updates'
+                ],
+                'errors': {
                     'missing': {
                         'x86_64': [
                             'SUSE-Enterprise-Storage-4-Updates'
@@ -107,7 +143,11 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             },
             'ha': {
                 'available': false,
-                'repos': {
+                'repos': [
+                    'SLE12-SP2-HA-Pool',
+                    'SLE12-SP2-HA-Updates'
+                ],
+                'errors': {
                     'missing': {
                         'x86_64': [
                             'SLE12-SP2-HA-Pool',
@@ -124,7 +164,11 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             },
             'os': {
                 'available': false,
-                'repos': {
+                'repos': [
+                    'SLES12-SP2-Pool',
+                    'SLES12-SP2-Updates'
+                ],
+                'errors': {
                     'missing': {
                         'x86_64': [
                             'SLES12-SP2-Pool'
@@ -139,7 +183,11 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             },
             'openstack': {
                 'available': true,
-                'repos': {}
+                'repos': [
+                    'SUSE-OpenStack-Cloud-7-Pool',
+                    'SUSE-OpenStack-Cloud-7-Updates'
+                ],
+                'errors': {}
             }
         },
         failingErrors = {
@@ -181,8 +229,7 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             'crowbarFactory',
             '$q',
             '$httpBackend',
-            '$rootScope',
-            'PRODUCTS_REPO_CHECKS_MAP'
+            '$rootScope'
         );
 
         bard.mockService(crowbarFactory, {

--- a/assets/app/features/upgrade/upgrade.constants.js
+++ b/assets/app/features/upgrade/upgrade.constants.js
@@ -2,12 +2,6 @@
 
     angular
         .module('crowbarApp.upgrade')
-        .constant('PRODUCTS_REPO_CHECKS_MAP', {
-            'os': ['SLES12-SP2-Pool', 'SLES12-SP2-Updates'],
-            'ha': ['SLE12-SP2-HA-Pool', 'SLE12-SP2-HA-Updates'],
-            'openstack': ['SUSE-OpenStack-Cloud-7-Pool', 'SUSE-OpenStack-Cloud-7-Updates'],
-            'ceph': ['SUSE-Enterprise-Storage-4-Pool', 'SUSE-Enterprise-Storage-4-Updates']
-        })
         .constant('ADDONS_PRECHECK_MAP', {
             'ha': ['clusters_healthy'],
             'ceph': ['ceph_healthy']

--- a/routes/api/upgrade/adminrepocheck.js
+++ b/routes/api/upgrade/adminrepocheck.js
@@ -7,11 +7,13 @@ router.get('/', function(req, res) {
     var data = {
         'os': {
             'available': true,
-            'repos': {}
+            'repos': ['SLES12-SP2-Pool', 'SLES12-SP2-Updates'],
+            'errors': {}
         },
         'openstack': {
             'available': false,
-            'repos': {
+            'repos': ['SUSE-OpenStack-Cloud-7-Pool', 'SUSE-OpenStack-Cloud-7-Updates'],
+            'errors': {
                 'x86_64': {
                     'missing': [
                         'SUSE-OpenStack-Cloud-7-Pool',
@@ -23,10 +25,8 @@ router.get('/', function(req, res) {
     };
 
     if (repo_correct) {
-        data['openstack'] = {
-            'available': true,
-            'repos': {}
-        }
+        data.openstack.available = true;
+        data.openstack.errors = {}
     }
     repo_correct = !repo_correct;
     res.status(200).json(data);


### PR DESCRIPTION
Backend provides mapping product to repositories in the repochecks
responses. It can be used instead of the PRODUCTS_REPO_CHECKS_MAP
constant.