### PR TITLE
upgrade: 'Prepare' call error handling

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
@@ -143,6 +143,8 @@
 
                     if (angular.isDefined(errorResponse.data.errors)) {
                         vm.errors = errorResponse.data;
+                    } else if (angular.isDefined(errorResponse.data.steps)) {
+                        vm.errors = { errors: errorResponse.data.steps.prepare.errors };
                     } else {
                         vm.errors = UNEXPECTED_ERROR_DATA;
                     }

--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -141,6 +141,7 @@
         "errors": {
             "default-title": "Upgrade Error",
             "prechecks": "Some Checks failed",
+            "prepare": "Begin Upgrade failed",
             "repocheck_nodes": "Some Checks failed",
             "maintenance_updates_installed": "Maintenance Updates",
             "clusters_health_crm_failures": "Some crm commands failed",


### PR DESCRIPTION
As 'prepare' is asyncronous, errors are put into the status data under steps.
These need to be checked in addition to regular errors to avoid "unexpected
error" message.