### PR TITLE
upgrade: Incrementally complete items in checklist

### DIFF
--- a/assets/app/widgets/crowbar-checklist/crowbar-checklist.directive.jade
+++ b/assets/app/widgets/crowbar-checklist/crowbar-checklist.directive.jade
@@ -2,13 +2,13 @@ ul.check-list
     li(ng-repeat="(checkKey, check) in checklist",
         check-key='{{::checkKey}}',
         ng-class="{\
-            'text-info': !completed,\
-            'text-success': check.status && completed,\
-            'text-danger': !check.status && completed\
+            'text-info': !completed && !check.completed,\
+            'text-success': check.status && (completed || check.completed),\
+            'text-danger': !check.status && (completed || check.completed)\
         }")
         i.glyphicon(ng-class="{\
-            'glyphicon-question-sign': !completed,\
-            'glyphicon-ok-sign': check.status && completed,\
-            'glyphicon-minus-sign': !check.status && completed\
+            'glyphicon-question-sign': !completed && !check.completed,\
+            'glyphicon-ok-sign': check.status && (completed || check.completed),\
+            'glyphicon-minus-sign': !check.status && (completed || check.completed)\
         }")
         span(translate='{{::check.label}}')


### PR DESCRIPTION
In some cases, checklist is used to show status of long running
process with multiple steps. One global `completed` flag is not enough
in such cases as the view will be updated after all steps are completed.

This change introduces an alternative way to control completion of check
items. Client should not set global `completed` attribute in the template
but set per-check `completed` field in the checks structure passed to the
directive.