### PR TITLE
upgrade: Add onFailed and postSync callbacks

### DIFF
--- a/assets/app/data/crowbar/services/upgrade-status.factory.js
+++ b/assets/app/data/crowbar/services/upgrade-status.factory.js
@@ -21,8 +21,11 @@
          * @param {Object} flagsObject - object with `running` and `completed` fields to be updated
          * @param {function} onRunning - Callback to be executed if current status is running
          * @param {function} onCompleted - Callback to be executed if current status is completed
+         * @param {function} [onFailed=undefined] - Callback to be executed if current status is failed
+         * @param {function} [postSync=undefined] - Callback to be executed after flags have been
+         *     synced and other callbacks executed
          */
-        function syncStatusFlags(step, flagsObject, onRunning, onCompleted) {
+        function syncStatusFlags(step, flagsObject, onRunning, onCompleted, onFailed, postSync) {
             upgradeFactory.getStatus()
                 .then(
                     function (response) {
@@ -33,7 +36,16 @@
                             onRunning();
                         } else if (flagsObject.completed && angular.isDefined(onCompleted)) {
                             onCompleted();
+                        } else if (response.data.steps[step].status == UPGRADE_STEP_STATES.failed) {
+                            if (angular.isFunction(onFailed)) {
+                                onFailed(response);
+                            }
                         }
+
+                        if (angular.isFunction(postSync)) {
+                            postSync();
+                        }
+
                     }
                 );
         }


### PR DESCRIPTION
When syncing status flags (usually on controller activation) there
can be cases where status of checked step is `failed`. Some actions
might be needed to cover this. An optional `onFailed` callback was
added for those cases.

The second (optional) added callback, `postSync` is called always
independent of the step status. This can be used to chain some action
after the status was synced as the syncing itself is asynchronous.