### PR TITLE
upgrade: Pass status response to postSync callback

### DIFF
--- a/assets/app/data/crowbar/services/upgrade-status.factory.js
+++ b/assets/app/data/crowbar/services/upgrade-status.factory.js
@@ -43,7 +43,7 @@
                         }
 
                         if (angular.isFunction(postSync)) {
-                            postSync();
+                            postSync(response);
                         }
 
                     }


### PR DESCRIPTION
The logic in postSync callback might require access to the response
received from the status call. Expose this as an argument to the
`postSync()` callback.