### PR TITLE
upgrade: Fix display of errors with duplicate lines

### DIFF
--- a/assets/app/widgets/suse-modal/suse-modal.directive.jade
+++ b/assets/app/widgets/suse-modal/suse-modal.directive.jade
@@ -9,7 +9,7 @@
             div.panel-heading {{ (translationPrefix + '.' + code) | translate }}
             div.panel-body
                 p.error-data
-                    span.error-line(ng-repeat="line in data.data | normalizeErrorData") {{ line }}
+                    span.error-line(ng-repeat="line in data.data | normalizeErrorData track by $index") {{ line }}
                 p.error-help(ng-if="data.help") {{ data.help }}
     .modal-footer
         button.btn.btn-default(type='button', ng-click='modalInstance.dismiss()')


### PR DESCRIPTION
By default ngRepeat requires the items to be unique. In case of error messages
some of the lines can easily be duplicated. This change switches to "track by index"
so that all lines are displayed properly.