### PR TITLE
upgrade: Split services/backup into two pages

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-nodes.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-nodes.controller.spec.js
@@ -58,10 +58,6 @@ describe('Upgrade Nodes Controller', function() {
                     status: stepStatus.pending,
                     errors: {}
                 },
-                finished: {
-                    status: stepStatus.pending,
-                    errors: {}
-                }
             }
         },
         initialStatusResponse = {
@@ -97,9 +93,6 @@ describe('Upgrade Nodes Controller', function() {
                     nodes: {
                         status: stepStatus.passed
                     },
-                    finished: {
-                        status: stepStatus.pending
-                    }
                 }
 
             }

--- a/assets/app/features/upgrade/controllers/upgrade-openstack-backup.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-openstack-backup.controller.js
@@ -1,0 +1,93 @@
+(function() {
+    'use strict';
+
+    /**
+    * @ngdoc function
+    * @name crowbarApp.upgrade.controller:UpgradeOpenStackBackupController
+    * @description
+    * # UpgradeOpenStackBackupController
+    * This is the controller used on the OpenStack Backup page
+    */
+    angular.module('crowbarApp.upgrade')
+        .controller('UpgradeOpenStackBackupController', UpgradeOpenStackBackupController);
+
+    UpgradeOpenStackBackupController.$inject = [
+        'upgradeFactory',
+        'upgradeStepsFactory',
+        'upgradeStatusFactory',
+        'UPGRADE_STEPS',
+        'UNEXPECTED_ERROR_DATA',
+        'OPENSTACK_BACKUP_TIMEOUT_INTERVAL',
+    ];
+    // @ngInject
+    function UpgradeOpenStackBackupController(
+        upgradeFactory,
+        upgradeStepsFactory,
+        upgradeStatusFactory,
+        UPGRADE_STEPS,
+        UNEXPECTED_ERROR_DATA,
+        OPENSTACK_BACKUP_TIMEOUT_INTERVAL
+    ) {
+        var vm = this;
+
+        vm.openStackBackup = {
+            completed: false,
+            running: false,
+            spinnerVisible: false,
+            createBackup: createBackup,
+        };
+
+        activate();
+
+        function activate() {
+            upgradeStatusFactory.syncStatusFlags(
+                UPGRADE_STEPS.backup_openstack, vm.openStackBackup,
+                waitForBackupToEnd, createBackupSuccess, createBackupError
+            );
+        }
+
+        /**
+         * Trigger creation of OpenStack backup
+         */
+        function createBackup() {
+            vm.openStackBackup.running = true;
+
+            upgradeFactory.createOpenstackBackup()
+                .then(
+                    waitForBackupToEnd,
+                    createBackupError
+                );
+        }
+
+        /**
+         * Start polling for status and wait until backup is created
+         */
+        function waitForBackupToEnd() {
+            upgradeStatusFactory.waitForStepToEnd(
+                UPGRADE_STEPS.backup_openstack,
+                OPENSTACK_BACKUP_TIMEOUT_INTERVAL,
+                createBackupSuccess,
+                createBackupError
+            );
+        }
+
+        function createBackupSuccess(/*response*/) {
+            vm.openStackBackup.running = false;
+            vm.openStackBackup.completed = true;
+
+            upgradeStepsFactory.setCurrentStepCompleted()
+        }
+
+        function createBackupError(errorResponse) {
+            vm.openStackBackup.running = false;
+            // Expose the error list
+            if (angular.isDefined(errorResponse.data.errors)) {
+                vm.errors = errorResponse.data;
+            } else if (angular.isDefined(errorResponse.data.steps)) {
+                vm.errors = { errors: errorResponse.data.steps.backup_openstack.errors };
+            } else {
+                vm.errors = UNEXPECTED_ERROR_DATA;
+            }
+        }
+    }
+})();

--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -94,14 +94,17 @@
                 }
             },
             "openstack-services": {
-                "title": "Stop OpenStack services and back up the OpenStack database",
-                "description": "It is imperative that during and after stopping the OpenStack services no changs are made to your cloud. After this step, OpenStack APIs will not be available until the upgrade process is finished. Once created, the backup can be found in /var/lib/crowbar/backup on Administration Server.",
-                "codes": {
-                    "services" : "Services stopped",
-                    "backup" : "Backup created"
-                },
+                "title": "Stop OpenStack services",
+                "description": "It is imperative that during and after stopping the OpenStack services no changes are made to your cloud. After this step, OpenStack APIs will not be available until the upgrade process is finished.",
                 "form": {
-                    "stop-services": "Stop Services and Create Backup"
+                    "stop-services": "Stop Services"
+                }
+            },
+            "openstack-backup": {
+                "title": "Back up the OpenStack database",
+                "description": "Backup of OpenStack database will be downloaded from one of database nodes and stored on the Administration Server. Depending on the size of your database this process might take quite some time. Once created, the backup can be found in /var/lib/crowbar/backup on Administration Server.",
+                "form": {
+                    "backup": "Create Backup"
                 }
             },
             "upgrade-nodes": {
@@ -137,7 +140,8 @@
                 "upgrade-administration-server": "Upgrade Administration Server",
                 "database-configuration": "Connect or Create Crowbar Database",
                 "nodes-repositories-checks": "Check Add-On & Node Repositories",
-                "openstack-services": "Back up OpenStack Database",
+                "openstack-services": "Stop OpenStack Services",
+                "openstack-backup": "Back up OpenStack Database",
                 "upgrade-nodes": "Upgrade Nodes & Reapply Barclamps"
             }
         },

--- a/assets/app/features/upgrade/steps.factory.js
+++ b/assets/app/features/upgrade/steps.factory.js
@@ -94,6 +94,13 @@
                 },
                 {
                     id: 6,
+                    title: 'upgrade.steps-key.codes.openstack-backup',
+                    state: 'upgrade.openstack-backup',
+                    active: false,
+                    finished: false
+                },
+                {
+                    id: 7,
                     title: 'upgrade.steps-key.codes.upgrade-nodes',
                     state: 'upgrade.upgrade-nodes',
                     active: false,
@@ -192,9 +199,8 @@
                     'database': 'upgrade.database-configuration',
                     'repocheck_nodes': 'upgrade.nodes-repositories-checks',
                     'services': 'upgrade.openstack-services',
-                    'backup_openstack': 'upgrade.openstack-services',
+                    'backup_openstack': 'upgrade.openstack-backup',
                     'nodes': 'upgrade.upgrade-nodes',
-                    'finished': 'upgrade.upgrade-nodes',
                 },
                 currentStep = statusData.current_step,
                 steps = statusData.steps,

--- a/assets/app/features/upgrade/steps.factory.spec.js
+++ b/assets/app/features/upgrade/steps.factory.spec.js
@@ -1,5 +1,5 @@
 /*global bard should assert expect upgradeStepsFactory module $state $q UPGRADE_LAST_STATE_KEY */
-describe('Stepes Factory', function () {
+describe('Steps Factory', function () {
     var mockedInitialSteps = [
         {
             id: 0,
@@ -45,6 +45,13 @@ describe('Stepes Factory', function () {
         },
         {
             id: 6,
+            title: 'upgrade.steps-key.codes.openstack-backup',
+            state: 'upgrade.openstack-backup',
+            active: false,
+            finished: false
+        },
+        {
+            id: 7,
             title: 'upgrade.steps-key.codes.upgrade-nodes',
             state: 'upgrade.upgrade-nodes',
             active: false,
@@ -86,9 +93,6 @@ describe('Stepes Factory', function () {
                 nodes: {
                     status: 'pending',
                 },
-                finished: {
-                    status: 'pending',
-                }
             }
         },
         statusDataAfterPrechecks = {
@@ -126,9 +130,6 @@ describe('Stepes Factory', function () {
                 nodes: {
                     status: 'pending',
                 },
-                finished: {
-                    status: 'pending',
-                }
             }
         },
         statusDataDuringPrepare = {
@@ -166,9 +167,6 @@ describe('Stepes Factory', function () {
                 nodes: {
                     status: 'pending',
                 },
-                finished: {
-                    status: 'pending',
-                }
             }
         },
         statusDataAfterPrepare = {
@@ -206,9 +204,6 @@ describe('Stepes Factory', function () {
                 nodes: {
                     status: 'pending',
                 },
-                finished: {
-                    status: 'pending',
-                }
             }
         },
         statusDataDuringBackup = {
@@ -246,9 +241,6 @@ describe('Stepes Factory', function () {
                 nodes: {
                     status: 'pending',
                 },
-                finished: {
-                    status: 'pending',
-                }
             }
         },
         statusDataAfterBackup = {
@@ -286,9 +278,6 @@ describe('Stepes Factory', function () {
                 nodes: {
                     status: 'pending',
                 },
-                finished: {
-                    status: 'pending',
-                }
             }
         },
         statusDataAfterAdminRepoChecks = {
@@ -326,9 +315,6 @@ describe('Stepes Factory', function () {
                 nodes: {
                     status: 'pending',
                 },
-                finished: {
-                    status: 'pending',
-                }
             },
         },
         statusDataAfterAdminUpgrade = {
@@ -366,9 +352,6 @@ describe('Stepes Factory', function () {
                 nodes: {
                     status: 'pending',
                 },
-                finished: {
-                    status: 'pending',
-                }
             }
         },
         statusDataAfterDatabase = {
@@ -406,9 +389,6 @@ describe('Stepes Factory', function () {
                 nodes: {
                     status: 'pending',
                 },
-                finished: {
-                    status: 'pending',
-                }
             }
         },
         statusDataAfterNodesRepoChecks = {
@@ -446,9 +426,6 @@ describe('Stepes Factory', function () {
                 nodes: {
                     status: 'pending',
                 },
-                finished: {
-                    status: 'pending',
-                }
             }
         },
         statusDataAfterNodesServices = {
@@ -486,9 +463,6 @@ describe('Stepes Factory', function () {
                 nodes: {
                     status: 'pending',
                 },
-                finished: {
-                    status: 'pending',
-                }
             }
         },
         statusDataAfterNodesDBDump = {
@@ -526,13 +500,10 @@ describe('Stepes Factory', function () {
                 nodes: {
                     status: 'pending',
                 },
-                finished: {
-                    status: 'pending',
-                }
             }
         },
         statusDataAfterNodesUpgrade = {
-            current_step: 'finished',
+            current_step: 'nodes',
             substep: null,
             current_node: null,
             steps: {
@@ -566,9 +537,6 @@ describe('Stepes Factory', function () {
                 nodes: {
                     status: 'passed',
                 },
-                finished: {
-                    status: 'pending',
-                }
             }
         };
 
@@ -776,9 +744,9 @@ describe('Stepes Factory', function () {
                     expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterNodesServices))
                         .toEqual('upgrade.openstack-services');
                 });
-                it('should return "upgrade.openstack-services" after nodes db dump', function() {
+                it('should return "upgrade.openstack-backup" after nodes db dump', function() {
                     expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterNodesDBDump))
-                        .toEqual('upgrade.openstack-services');
+                        .toEqual('upgrade.openstack-backup');
                 });
                 it('should return "upgrade.upgrade-nodes" after nodes upgrade', function() {
                     expect(upgradeStepsFactory.lastStateForRestore(statusDataAfterNodesUpgrade))

--- a/assets/app/features/upgrade/templates/openstack-backup.jade
+++ b/assets/app/features/upgrade/templates/openstack-backup.jade
@@ -1,0 +1,16 @@
+h2(translate='') upgrade.steps.openstack-backup.title
+p(translate='') upgrade.steps.openstack-backup.description
+
+button.btn.btn-success.center-block(
+    ng-click='upgradeOpenStackBackupVm.openStackBackup.createBackup()',
+    ng-disabled='upgradeOpenStackBackupVm.openStackBackup.running || upgradeOpenStackBackupVm.openStackBackup.completed',
+    ng-class='{\
+        "spinner-visible": upgradeOpenStackBackupVm.openStackBackup.spinnerVisible,\
+        active: upgradeOpenStackBackupVm.openStackBackup.running \
+    }',
+)
+    suse-lazy-spinner(delay='2000', active='upgradeOpenStackBackupVm.openStackBackup.running',
+        visible='upgradeOpenStackBackupVm.openStackBackup.spinnerVisible')
+    span(translate='') upgrade.steps.openstack-backup.form.backup
+
+suse-modal(error="upgradeOpenStackBackupVm.errors", translation-prefix="upgrade.errors")

--- a/assets/app/features/upgrade/templates/openstack-services.jade
+++ b/assets/app/features/upgrade/templates/openstack-services.jade
@@ -3,16 +3,14 @@ p(translate='') upgrade.steps.openstack-services.description
 
 button.btn.btn-success.center-block(
     ng-click='upgradeOpenStackServicesVm.openStackServices.stopServices()',
-    ng-disabled='upgradeOpenStackServicesVm.checks.services.running || \
-        upgradeOpenStackServicesVm.checks.backup.status || upgradeOpenStackServicesVm.checks.backup.running',
+    ng-disabled='upgradeOpenStackServicesVm.openStackServices.running || upgradeOpenStackServicesVm.openStackServices.completed',
     ng-class='{\
         "spinner-visible": upgradeOpenStackServicesVm.openStackServices.spinnerVisible,\
-        active: upgradeOpenStackServicesVm.checks.services.running || upgradeOpenStackServicesVm.checks.backup.running \
+        active: upgradeOpenStackServicesVm.openStackServices.running \
     }',
 )
-    suse-lazy-spinner(delay='2000', active='upgradeOpenStackServicesVm.checks.services.running || upgradeOpenStackServicesVm.checks.backup.running',
+    suse-lazy-spinner(delay='2000', active='upgradeOpenStackServicesVm.openStackServices.running',
         visible='upgradeOpenStackServicesVm.openStackServices.spinnerVisible')
     span(translate='') upgrade.steps.openstack-services.form.stop-services
 
-crowbar-checklist(checklist='upgradeOpenStackServicesVm.checks')
 suse-modal(error="upgradeOpenStackServicesVm.errors", translation-prefix="upgrade.errors")

--- a/assets/app/features/upgrade/upgrade.config.js
+++ b/assets/app/features/upgrade/upgrade.config.js
@@ -61,6 +61,12 @@
                 controller: 'UpgradeOpenStackServicesController',
                 controllerAs: 'upgradeOpenStackServicesVm'
             })
+            .state('upgrade.openstack-backup', {
+                url: '/openstack-backup',
+                templateUrl: 'app/features/upgrade/templates/openstack-backup.html',
+                controller: 'UpgradeOpenStackBackupController',
+                controllerAs: 'upgradeOpenStackBackupVm'
+            })
             .state('upgrade.upgrade-nodes', {
                 url: '/upgrade-nodes',
                 templateUrl: 'app/features/upgrade/templates/upgrade-nodes-page.html',

--- a/assets/index.jade
+++ b/assets/index.jade
@@ -61,6 +61,7 @@ html(ng-app='crowbarApp')
     script(src='app/features/upgrade/controllers/upgrade-database-configuration.controller.js')
     script(src='app/features/upgrade/controllers/upgrade-nodes-repositories-checks.controller.js')
     script(src='app/features/upgrade/controllers/upgrade-openstack-services.controller.js')
+    script(src='app/features/upgrade/controllers/upgrade-openstack-backup.controller.js')
     script(src='app/features/upgrade/controllers/upgrade-nodes.controller.js')
 
     // Templates


### PR DESCRIPTION
As those two steps are not really related, the UI was modified so that
they are handled on two separate pages. The logic is way less complicated
after this change as there's no need to 'enforce' the sequential execution
of those steps inside the controller or show the status of those 'sub-steps'.