### PR TITLE
upgrade: Pass response to all sync callbacks

### DIFF
--- a/assets/app/data/crowbar/services/upgrade-status.factory.js
+++ b/assets/app/data/crowbar/services/upgrade-status.factory.js
@@ -33,9 +33,9 @@
                         flagsObject.completed = response.data.steps[step].status === UPGRADE_STEP_STATES.passed;
 
                         if (flagsObject.running && angular.isDefined(onRunning)) {
-                            onRunning();
+                            onRunning(response);
                         } else if (flagsObject.completed && angular.isDefined(onCompleted)) {
-                            onCompleted();
+                            onCompleted(response);
                         } else if (response.data.steps[step].status == UPGRADE_STEP_STATES.failed) {
                             if (angular.isFunction(onFailed)) {
                                 onFailed(response);


### PR DESCRIPTION
Having access to response data in callbacks passed to `syncStatusFlags` is
useful in some situations. Response was already passed to onFailed. This
change adds the response argument to remainings ones. Additional benefit
is that it makes the callback calls compatible with the ones from
`waitForStepToEnd` so the same functions can be reused.