### PR TITLE
upgrade: Display backup paths after creation

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-backup.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-backup.controller.js
@@ -42,6 +42,12 @@ function() {
             spinnerVisible: false
         };
 
+        activate();
+
+        function activate() {
+            updateBackupFilePath();
+        }
+
         function createBackup() {
             vm.backup.running = true;
 
@@ -50,6 +56,7 @@ function() {
                     function (response) {
                         // the ID should always be returned in a successfull response
                         vm.backup.download(response.data.id);
+                        updateBackupFilePath();
                     },
                     // In case of backup error
                     function (errorResponse) {
@@ -59,6 +66,15 @@ function() {
                             vm.backup.errors = UNEXPECTED_ERROR_DATA;
                         }
                         vm.backup.running = false;
+                    }
+                );
+        }
+
+        function updateBackupFilePath() {
+            upgradeFactory.getStatus()
+                .then(
+                    function (response) {
+                        vm.backup.backupPath = response.data.crowbar_backup;
                     }
                 );
         }

--- a/assets/app/features/upgrade/controllers/upgrade-backup.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-backup.controller.spec.js
@@ -22,6 +22,11 @@ describe('Upgrade Flow - Backup Controller', function() {
         mockedDownloadResponse = {
             data: new Blob([mockedDownloadFile]),
             'headers': function() {}
+        },
+        mockedStatusResponse = {
+            data: {
+                crowbar_backup: '--some path--',
+            }
         };
 
     beforeEach(function() {
@@ -36,6 +41,11 @@ describe('Upgrade Flow - Backup Controller', function() {
             'crowbarUtilsFactory',
             'FileSaver'
         );
+
+        bard.mockService(upgradeFactory, {
+            getStatus: $q.when(mockedStatusResponse),
+            createAdminBackup: $q.when(mockedCreateResponse),
+        });
 
         //Create the controller
         controller = $controller('UpgradeBackupController');
@@ -74,9 +84,6 @@ describe('Upgrade Flow - Backup Controller', function() {
                 beforeEach(function () {
                     spyOn(controller.backup, 'download');
 
-                    bard.mockService(upgradeFactory, {
-                        createAdminBackup: $q.when(mockedCreateResponse)
-                    });
                     controller.backup.create();
                     $rootScope.$digest();
                 });
@@ -97,10 +104,8 @@ describe('Upgrade Flow - Backup Controller', function() {
             describe('when executed and finished with failure', function () {
                 beforeEach(function () {
                     spyOn(controller.backup, 'download');
-
-                    bard.mockService(upgradeFactory, {
-                        createAdminBackup: $q.reject(mockedErrorResponse)
-                    });
+                    // local change in mocked service
+                    spyOn(upgradeFactory, 'createAdminBackup').and.returnValue($q.reject(mockedErrorResponse));
                     controller.backup.create();
                     $rootScope.$digest();
                 });

--- a/assets/app/features/upgrade/controllers/upgrade-openstack-backup.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-openstack-backup.controller.js
@@ -71,9 +71,11 @@
             );
         }
 
-        function createBackupSuccess(/*response*/) {
+        function createBackupSuccess(response) {
             vm.openStackBackup.running = false;
             vm.openStackBackup.completed = true;
+
+            vm.openStackBackup.backupPath = response.data.openstack_backup;
 
             upgradeStepsFactory.setCurrentStepCompleted()
         }

--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -53,7 +53,8 @@
                 "description": "This backup contains information about the cloud deployment and configuration. Keep this backup somewhere safe in case of emergency.",
                 "form": {
                     "backup": "Download Backup of Administration Server"
-                }
+                },
+                "location": "Backup can be found under \"{{path}}\" on Administration Server."
             },
             "admin-repository-checks": {
                 "title": "Upgrading to SUSE OpenStack Cloud 7 requires updated software repositories for the Administration Server",
@@ -105,7 +106,8 @@
                 "description": "Backup of OpenStack database will be downloaded from one of database nodes and stored on the Administration Server. Depending on the size of your database this process might take quite some time. Once created, the backup can be found in /var/lib/crowbar/backup on Administration Server.",
                 "form": {
                     "backup": "Create Backup"
-                }
+                },
+                "location": "Backup can be found under \"{{path}}\" on Administration Server."
             },
             "upgrade-nodes": {
                 "title": "Begin upgrading and migrating nodes by clicking on the button below",

--- a/assets/app/features/upgrade/templates/backup-page.jade
+++ b/assets/app/features/upgrade/templates/backup-page.jade
@@ -11,4 +11,9 @@ button.btn.btn-primary.center-block(
   suse-lazy-spinner(delay="2000", active="upgradeBackupVm.backup.running",
     visible="upgradeBackupVm.backup.spinnerVisible")
   span(translate='') upgrade.steps.backup.form.backup
+div.backup-location.step-hint(
+  ng-if="upgradeBackupVm.backup.backupPath",
+  translate='upgrade.steps.backup.location',
+  translate-values='{ path: upgradeBackupVm.backup.backupPath }'
+)
 suse-modal(error="upgradeBackupVm.backup.errors", translation-prefix="upgrade.errors")

--- a/assets/app/features/upgrade/templates/openstack-backup.jade
+++ b/assets/app/features/upgrade/templates/openstack-backup.jade
@@ -12,5 +12,9 @@ button.btn.btn-success.center-block(
     suse-lazy-spinner(delay='2000', active='upgradeOpenStackBackupVm.openStackBackup.running',
         visible='upgradeOpenStackBackupVm.openStackBackup.spinnerVisible')
     span(translate='') upgrade.steps.openstack-backup.form.backup
-
+div.backup-location.step-hint(
+  ng-if="upgradeOpenStackBackupVm.openStackBackup.backupPath",
+  translate='upgrade.steps.openstack-backup.location',
+  translate-values='{ path: upgradeOpenStackBackupVm.openStackBackup.backupPath }'
+)
 suse-modal(error="upgradeOpenStackBackupVm.errors", translation-prefix="upgrade.errors")

--- a/assets/app/features/upgrade/upgrade.less
+++ b/assets/app/features/upgrade/upgrade.less
@@ -1,4 +1,5 @@
 /* Start= states/upgrade/upgrade.less */
+@import 'font-awesome';
 
 .upgrade-flow {
     border-color: #cccccc;
@@ -89,6 +90,22 @@
                 .checks-container .btn {
                     margin-bottom: 0px;
                     margin-top: 20px;
+                }
+
+                .step-hint {
+                    color: @success-text;
+
+                    &:before {
+                        color: @success-icon;
+                        content: @fa-var-info-circle;
+                        font-family: FontAwesome;
+                        font-size: 16px;
+                        margin-right: 5px;
+                    }
+                }
+
+                .backup-location {
+                    margin-top: 24px;
                 }
             }
         }


### PR DESCRIPTION
Status library returns paths where backups can be found after they are created.
This change exposes those paths in the UI.