### PR TITLE
upgrade: Add missing charset declaration

### DIFF
--- a/assets/index.jade
+++ b/assets/index.jade
@@ -5,6 +5,7 @@ html(ng-app='crowbarApp')
     link(rel='stylesheet', href='/css/bower_components.min.css')
     link(rel='stylesheet', href='/css/app.css')
     link(rel='shortcut icon', href='/images/favicon.ico', type='image/x-icon')
+    meta(charset='utf-8')
   body
     crowbar-header
 


### PR DESCRIPTION
Without this, Firefox throws lots of warnings in the console about missing charset declaration. (i.e. The character encoding of the HTML document was not declared).