### PR TITLE
upgrade: OpenStack precheck UI

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
@@ -72,7 +72,11 @@
                 compute_status: {
                     status: false,
                     label: 'upgrade.steps.landing.prechecks.codes.compute_status'
-                }
+                },
+                openstack_check: {
+                    status: false,
+                    label: 'upgrade.steps.landing.prechecks.codes.openstack_check'
+                },
             },
             runPrechecks: runPrechecks
         };

--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
@@ -139,7 +139,8 @@ describe('Upgrade Landing Controller', function() {
             cloud_healthy: { required: true, passed: true },
             clusters_healthy: { required: false, passed: true },
             ceph_healthy: { required: false, passed: true },
-            compute_status: { required: false, passed: true }
+            compute_status: { required: false, passed: true },
+            openstack_check: { required: false, passed: true },
         },
         failingChecks = {
             maintenance_updates_installed: { required: true, passed: false,
@@ -153,7 +154,9 @@ describe('Upgrade Landing Controller', function() {
             ceph_healthy: { required: false, passed: false,
                 errors: { err5: { data: 'err5 data', help: 'err5 help' }} },
             compute_status: { required: false, passed: false,
-                errors: { err6: { data: 'err6 data', help: 'err6 help' }} }
+                errors: { err6: { data: 'err6 data', help: 'err6 help' }} },
+            openstack_check: { required: true, passed: false,
+                errors: { err7: { data: 'err7 data', help: 'err7 help' }} },
         },
         partiallyFailingChecks = {
             maintenance_updates_installed: { required: true, passed: true },
@@ -163,7 +166,8 @@ describe('Upgrade Landing Controller', function() {
                 errors: { err7: { data: 'err7 data', help: 'err7 help' }} },
             ceph_healthy: { required: false, passed: false,
                 errors: { err8: { data: 'err8 data', help: 'err8 help' }} },
-            compute_status: { required: true, passed: true }
+            compute_status: { required: true, passed: true },
+            openstack_check: { required: true, passed: true },
         },
         failingErrors = {
             error_message: 'Authentication failure'

--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -22,6 +22,7 @@
                         "cloud_health": "Cloud Health",
                         "high_availability": "High Availability Health",
                         "storage": "Storage Health",
+                        "openstack_check": "OpenStack Check",
                         "compute_status": "Compute Resources"
                     }
                 },
@@ -155,6 +156,7 @@
             "no_resources": "Not enough free compute resources",
             "zypper_errors": "Zypper error",
             "failed_proposals": "Failed proposals",
+            "too_many_replicas": "Too many Swift replicas",
             "repositories_missing": "Required repositories missing",
             "repositories_too_soon": "SOC7 repositories found",
             "prepare": "Begin Upgrade failed",


### PR DESCRIPTION
New pre-check was added in the backend to cover verification of
various OpenStack services readiness for SOC7. The UI was updated
accordingly.

Related backend PR: https://github.com/crowbar/crowbar-core/pull/1107