### PR TITLE
upgrade: Display node names instead of IPs

### DIFF
--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -117,7 +117,7 @@
                 },
                 "status": {
                     "progress-bar": "{{current}} of {{total}} Nodes Upgraded",
-                    "current-node": "Current Node: {{nodeIP}}",
+                    "current-node": "Current Node: {{nodeName}}",
                     "node-role": "Node Role: {{nodeRole}}",
                     "node-status": "Status: {{status}}"
                 }

--- a/assets/app/features/upgrade/templates/upgrade-nodes-page.jade
+++ b/assets/app/features/upgrade/templates/upgrade-nodes-page.jade
@@ -20,6 +20,7 @@
     .row(ng-if="upgradeNodesVm.nodesUpgrade.currentNode")
         .col-md-8.col-md-offset-4
             .upgrade-progress(
+                title='{{upgradeNodesVm.nodesUpgrade.currentNode.ip}}',
                 translate='upgrade.steps.upgrade-nodes.status.current-node',
                 translate-values='{"nodeIP": upgradeNodesVm.nodesUpgrade.currentNode.ip, "nodeName": upgradeNodesVm.nodesUpgrade.currentNode.name}'
             )


### PR DESCRIPTION
On the "upgrade-nodes" page, the current node was displayed as IP address.
This change switches this to DNS name / FQDN of the node. The IP is still
accessible as tooltip over the node name.