### PR TITLE
upgrade: Show ha_configured precheck in UI

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
@@ -77,6 +77,10 @@
                     status: false,
                     label: 'upgrade.steps.landing.prechecks.codes.openstack_check'
                 },
+                ha_configured: {
+                    status: false,
+                    label: 'upgrade.steps.landing.prechecks.codes.ha_configured'
+                },
             },
             runPrechecks: runPrechecks
         };

--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
@@ -141,6 +141,7 @@ describe('Upgrade Landing Controller', function() {
             ceph_healthy: { required: false, passed: true },
             compute_status: { required: false, passed: true },
             openstack_check: { required: false, passed: true },
+            ha_configured: { required: false, passed: true },
         },
         failingChecks = {
             maintenance_updates_installed: { required: true, passed: false,
@@ -157,6 +158,8 @@ describe('Upgrade Landing Controller', function() {
                 errors: { err6: { data: 'err6 data', help: 'err6 help' }} },
             openstack_check: { required: true, passed: false,
                 errors: { err7: { data: 'err7 data', help: 'err7 help' }} },
+            ha_configured: { required: false, passed: false,
+                errors: { err8: { data: 'err8 data', help: 'err8 help' }} },
         },
         partiallyFailingChecks = {
             maintenance_updates_installed: { required: true, passed: true },
@@ -168,6 +171,7 @@ describe('Upgrade Landing Controller', function() {
                 errors: { err8: { data: 'err8 data', help: 'err8 help' }} },
             compute_status: { required: true, passed: true },
             openstack_check: { required: true, passed: true },
+            ha_configured: { required: false, passed: true },
         },
         failingErrors = {
             error_message: 'Authentication failure'

--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -23,6 +23,7 @@
                         "high_availability": "High Availability Health",
                         "storage": "Storage Health",
                         "openstack_check": "OpenStack Check",
+                        "ha_configured": "High Availability Setup",
                         "compute_status": "Compute Resources"
                     }
                 },
@@ -39,7 +40,7 @@
                         "button": "Proceed in Normal Mode",
                         "description-title": "IMPORTANT!",
                         "description1": "In normal mode, the workloads running in each node will be live-migrated to another node. Note that you will lose connection to your VMs when upgrading the control node(s).",
-                        "description2": "In order to proceed in non-disruptive mode your cloud needs to be Highly Available and have enough free compute resources. See the deployment guide for details.",
+                        "description2": "In order to proceed in non-disruptive mode your cloud needs to be configured as Highly Available and have enough free compute resources. See the deployment guide for details.",
                         "description3": "Be sure to re-run the checks if you make any changes to your cloud after the initial run."
                     },
                     "nondisruptive": {
@@ -151,6 +152,8 @@
         "errors": {
             "default-title": "Upgrade Error",
             "prechecks": "Some Checks failed",
+            "ha_configured": "Cloud is not configured as Highly Available",
+            "ha_not_installed": "High Availability module is not present",
             "nodes_not_ready": "Nodes not ready",
             "no_live_migration": "Live migration not configured",
             "no_resources": "Not enough free compute resources",


### PR DESCRIPTION
If HA is not configured, UI switched to "Normal" mode but didn't
explicitly say why. This info is returned in ha_configured precheck's
error data and is now displayed as other prechecks.