### PR TITLE
upgrade: Yellow failures of non-required checks

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.js
@@ -188,6 +188,7 @@
                             // skip unknown checks returned from backend
                             if (checkKey in vm.prechecks.checks) {
                                 vm.prechecks.checks[checkKey].status = check.passed;
+                                vm.prechecks.checks[checkKey].optional = !check.required;
                                 if (check.errors) {
                                     _.merge(checksErrors, check.errors);
                                 }

--- a/assets/app/widgets/crowbar-checklist/crowbar-checklist.directive.jade
+++ b/assets/app/widgets/crowbar-checklist/crowbar-checklist.directive.jade
@@ -4,7 +4,8 @@ ul.check-list
         ng-class="{\
             'text-info': !completed && !check.completed,\
             'text-success': check.status && (completed || check.completed),\
-            'text-danger': !check.status && (completed || check.completed)\
+            'text-warning': !check.status && check.optional && (completed || check.completed),\
+            'text-danger': !check.status && !check.optional && (completed || check.completed)\
         }")
         i.glyphicon(ng-class="{\
             'glyphicon-question-sign': !completed && !check.completed,\

--- a/assets/app/widgets/crowbar-checklist/crowbar-checklist.less
+++ b/assets/app/widgets/crowbar-checklist/crowbar-checklist.less
@@ -37,6 +37,17 @@ crowbar-checklist {
             }
         }
 
+        .text-warning {
+
+            i {
+                color: @warning-icon;
+            }
+
+            span {
+                color: @warning-text;
+            }
+        }
+
         .text-success {
 
             i {

--- a/assets/content/less/variables.less
+++ b/assets/content/less/variables.less
@@ -13,6 +13,8 @@
 @info-icon: #a7a9ac;
 @success-text: #16996e;
 @success-icon: #00c081;
+@warning-text: #ed6924;
+@warning-icon: #fd9a2b;
 @danger-text: #ca3a4c;
 @danger-icon: #cd2c40;
 

--- a/routes/api/upgrade/prechecks.js
+++ b/routes/api/upgrade/prechecks.js
@@ -18,7 +18,9 @@ router.get('/', function(req, res) {
                 'cloud_healthy': { required: true, passed: checksPass },
                 'clusters_healthy': { required: false, passed: false },
                 'ceph_healthy': { required: false, passed: checksPass },
-                'compute_status': { required: true, passed: true }
+                'compute_status': { required: true, passed: true },
+                'ha_configured': { required: false, passed: true },
+                'openstack_check': { required: true, passed: checksPass },
             },
             'best_method': bestMethod ? 'non-disruptive' : 'disruptive'
         });


### PR DESCRIPTION
Prechecks marked as not required for the upgrade are only important
for the non-disruptive mode. Their failures are not fatal so they
should not use red color as it might be misleading for the user.

![zrzut ekranu z 2017-03-02 12-46-01](https://cloud.githubusercontent.com/assets/2458112/23506854/93f021d2-ff4a-11e6-9b61-de2ac2365d91.png)
