### PR TITLE
upgrade: Update progress on error response too

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-nodes.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-nodes.controller.js
@@ -82,12 +82,12 @@
         }
 
         function updateModel(response) {
-            // do nothing if called with error response (e.g. via postSync)
+            // do nothing if called with error-only response (e.g. via postSync)
             if (response.data.errors) {
                 return;
             }
             // nodes info is not available in main status response before step is started
-            if (!response.data.current_node) {
+            if (response.data.remaining_nodes === null) {
                 // fetch base counts from the nodes status api
                 upgradeFactory.getNodesStatus()
                     .then(
@@ -107,6 +107,9 @@
         }
 
         function upgradeError(errorResponse) {
+            // make sure we update the UI with latest status even if it contained errors
+            updateModel(errorResponse);
+
             vm.nodesUpgrade.running = false;
             // Expose the error list to nodesUpgrade object
             if (angular.isDefined(errorResponse.data.errors)) {

--- a/assets/app/features/upgrade/controllers/upgrade-nodes.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-nodes.controller.spec.js
@@ -223,7 +223,7 @@ describe('Upgrade Nodes Controller', function() {
         });
     });
 
-    describe('On syncStatusFlags success', function () {
+    describe('On running syncStatusFlags success', function () {
         beforeEach(function () {
             spyOn(upgradeStatusFactory, 'syncStatusFlags').and.callFake(
                 function(step, flagsObject, onRunning, onSuccess, onError, postSync) {
@@ -233,6 +233,10 @@ describe('Upgrade Nodes Controller', function() {
             );
 
             spyOn(upgradeStatusFactory, 'waitForStepToEnd');
+
+            bard.mockService(upgradeFactory, {
+                getNodesStatus: $q.when(initialNodesResponse),
+            });
 
             controller = $controller('UpgradeNodesController');
 


### PR DESCRIPTION
When nodes upgrade returns error, the same response can contain updated
progress info. It will now be used to update the progress UI.