### PR TITLE
upgrade: Rename disruptive to normal

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
@@ -183,7 +183,7 @@ describe('Upgrade Landing Controller', function() {
             data: { checks: failingChecks, best_method: 'none' }
         },
         partiallyFailingChecksResponse = {
-            data: { checks: partiallyFailingChecks, best_method: 'disruptive' }
+            data: { checks: partiallyFailingChecks, best_method: 'normal' }
         },
         failingResponse = {
             data: {
@@ -458,7 +458,7 @@ describe('Upgrade Landing Controller', function() {
                     assert.isTrue(controller.prechecks.completed);
                 });
 
-                it('should update valid attribute of checks model to true (disruptive only)', function () {
+                it('should update valid attribute of checks model to true (normal only)', function () {
                     assert.isTrue(controller.prechecks.valid);
                 });
 
@@ -469,8 +469,8 @@ describe('Upgrade Landing Controller', function() {
                     });
                 });
 
-                it('should set the mode to disruptive', function () {
-                    expect(controller.mode.type).toEqual('disruptive');
+                it('should set the mode to normal', function () {
+                    expect(controller.mode.type).toEqual('normal');
                 });
 
                 it('should set the mode.valid to false', function () {
@@ -487,8 +487,8 @@ describe('Upgrade Landing Controller', function() {
                         $rootScope.$digest();
                     });
 
-                    it('mode should be disruptive', function () {
-                        expect(controller.mode.type).toEqual('disruptive');
+                    it('mode should be normal', function () {
+                        expect(controller.mode.type).toEqual('normal');
                     });
 
                     it('should set the mode.valid to true', function () {

--- a/assets/app/features/upgrade/templates/landing-page_step2.partial.jade
+++ b/assets/app/features/upgrade/templates/landing-page_step2.partial.jade
@@ -5,10 +5,10 @@
 .initial(ng-if='upgradeLandingVm.mode.type === "none"')
     p(translate='') upgrade.steps.landing.mode.description
 
-.normal(ng-if='upgradeLandingVm.mode.type === "disruptive"')
+.normal(ng-if='upgradeLandingVm.mode.type === "normal"')
     h3.h5(translate='') upgrade.steps.landing.mode.normal.title
     button.btn.btn-primary.mode-button(
-        ng-disabled="upgradeLandingVm.mode.type != 'disruptive' || upgradeLandingVm.mode.valid",
+        ng-disabled="upgradeLandingVm.mode.type != 'normal' || upgradeLandingVm.mode.valid",
         ng-click="upgradeLandingVm.continueNormal()"
     )
         span(translate='') upgrade.steps.landing.mode.normal.button

--- a/assets/app/features/upgrade/upgrade.constants.js
+++ b/assets/app/features/upgrade/upgrade.constants.js
@@ -24,7 +24,7 @@
         .constant('OPENSTACK_BACKUP_TIMEOUT_INTERVAL', 1000)
         .constant('UPGRADE_MODES', {
             nondisruptive: 'non-disruptive',
-            disruptive: 'disruptive',
+            normal: 'normal',
             none: 'none',
         });
 })();

--- a/routes/api/upgrade/prechecks.js
+++ b/routes/api/upgrade/prechecks.js
@@ -20,7 +20,7 @@ router.get('/', function(req, res) {
                 'ceph_healthy': { required: false, passed: checksPass },
                 'compute_status': { required: true, passed: true }
             },
-            'best_method': bestMethod ? 'non-disruptive' : 'disruptive'
+            'best_method': bestMethod ? 'non-disruptive' : 'normal'
         });
     }
     checksPass = true;


### PR DESCRIPTION
The backend renamed 'disruptive' mode to 'normal'. UI was updated
to match this.

This is frontend update for https://github.com/crowbar/crowbar-core/pull/1129