### PR TITLE
upgrade: Indicate completed database step

### DIFF
--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -76,6 +76,7 @@
             },
             "database-configuration": {
                 "title": "Enter Credentials and/or Information to create or connect to a PostgreSQL service to be used for serving the Crowbar database",
+                "title-completed": "This step has been completed. Click on \"Next\" to continue the upgrade process.",
                 "navigation-tabs": {
                     "create-database": "Create a Database",
                     "connect-database": "Connect to a Database"

--- a/assets/app/features/upgrade/templates/database-configuration-page.jade
+++ b/assets/app/features/upgrade/templates/database-configuration-page.jade
@@ -1,5 +1,6 @@
 .database-configuration-page
-    h2(translate='') upgrade.steps.database-configuration.title
+    h2(translate='', ng-if='!upgradeDatabaseVm.completed') upgrade.steps.database-configuration.title
+    h2(translate='', ng-if='upgradeDatabaseVm.completed') upgrade.steps.database-configuration.title-completed
     uib-tabset
         uib-tab(index='0', disable='upgradeDatabaseVm.running || upgradeDatabaseVm.completed',
         heading="{{'upgrade.steps.database-configuration.navigation-tabs.create-database' | translate}}")
@@ -11,6 +12,7 @@
                             input.form-control(type='text', name='username',
                             minlength='4', maxlength='63',
                             ng-pattern='upgradeDatabaseVm.patterns.username',
+                            ng-disabled='upgradeDatabaseVm.running || upgradeDatabaseVm.completed',
                             required='', ng-model='upgradeDatabaseVm.databaseForm.username')
                     .col-md-8
                         .form-group(ng-class="{'has-error': newForm.password.$invalid && newForm.password.$dirty}")
@@ -18,6 +20,7 @@
                             input.form-control(type='password', name='password',
                             minlength='4', maxlength='63',
                             ng-pattern='upgradeDatabaseVm.patterns.password',
+                            ng-disabled='upgradeDatabaseVm.running || upgradeDatabaseVm.completed',
                             required='', ng-model='upgradeDatabaseVm.databaseForm.password')
                     .col-md-4
                         button.btn.btn-success.pull-left.btn-lg(
@@ -43,6 +46,7 @@
                                 input.form-control(type='text', name='host',
                                 minlength='1', maxlength='253',
                                 ng-pattern='upgradeDatabaseVm.patterns.host',
+                                ng-disabled='upgradeDatabaseVm.running || upgradeDatabaseVm.completed',
                                 required='', ng-model='upgradeDatabaseVm.databaseForm.host')
                     .col-md-4
                         .form-group(ng-class="{'has-error': existingForm.port.$invalid && existingForm.port.$dirty}")
@@ -50,6 +54,7 @@
                                 label.control-label(for='port', translate='') upgrade.steps.database-configuration.database-form.port
                                 input.form-control(type='number', name='port',
                                 min='1', max='65535',
+                                ng-disabled='upgradeDatabaseVm.running || upgradeDatabaseVm.completed',
                                 required='', ng-model='upgradeDatabaseVm.databaseForm.port')
                     .col-md-8
                         .form-group(ng-class="{'has-error': existingForm.username.$invalid && existingForm.username.$dirty}")
@@ -57,6 +62,7 @@
                             input.form-control(type='text', name='username',
                             minlength='4', maxlength='63',
                             ng-pattern='upgradeDatabaseVm.patterns.username',
+                            ng-disabled='upgradeDatabaseVm.running || upgradeDatabaseVm.completed',
                             required='', ng-model='upgradeDatabaseVm.databaseForm.username')
                     .col-md-8
                         .form-group(ng-class="{'has-error': existingForm.password.$invalid && existingForm.password.$dirty}")
@@ -64,6 +70,7 @@
                             input.form-control(type='password', name='password',
                             minlength='4', maxlength='63',
                             ng-pattern='upgradeDatabaseVm.patterns.password',
+                            ng-disabled='upgradeDatabaseVm.running || upgradeDatabaseVm.completed',
                             required='', ng-model='upgradeDatabaseVm.databaseForm.password')
                     .col-md-4
                         button.btn.btn-success.pull-left.btn-lg(


### PR DESCRIPTION
The title on database configuration page changes after the step is completed
to avoid confusion (e.g. when re-opening the UI).
Also the form fields are disabled when database configuration is running or
completed to clearly indicate that this data cannot be modified anymore.

![zrzut ekranu z 2017-03-03 14-18-29](https://cloud.githubusercontent.com/assets/2458112/23552468/4b93de10-001c-11e7-8a7d-ac7f6c1d0637.png)