### PR TITLE
upgrade: rename non-disruptive to non_disruptive

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-landing.controller.spec.js
@@ -177,7 +177,7 @@ describe('Upgrade Landing Controller', function() {
             error_message: 'Authentication failure'
         },
         passingChecksResponse = {
-            data: { checks: passingChecks, best_method: 'non-disruptive' }
+            data: { checks: passingChecks, best_method: 'non_disruptive' }
         },
         failingChecksResponse = {
             data: { checks: failingChecks, best_method: 'none' }
@@ -405,8 +405,8 @@ describe('Upgrade Landing Controller', function() {
                     });
                 });
 
-                it('should set the mode to non-disruptive', function () {
-                    expect(controller.mode.type).toEqual('non-disruptive');
+                it('should set the mode to non_disruptive', function () {
+                    expect(controller.mode.type).toEqual('non_disruptive');
                 });
 
                 it('should set the mode.valid to true', function () {

--- a/assets/app/features/upgrade/templates/landing-page_step2.partial.jade
+++ b/assets/app/features/upgrade/templates/landing-page_step2.partial.jade
@@ -17,7 +17,7 @@
     p(translate='') upgrade.steps.landing.mode.normal.description2
     p(translate='') upgrade.steps.landing.mode.normal.description3
 
-.nondisruptive(ng-if='upgradeLandingVm.mode.type === "non-disruptive"')
+.nondisruptive(ng-if='upgradeLandingVm.mode.type === "non_disruptive"')
     h3.h5(translate='') upgrade.steps.landing.mode.nondisruptive.title
     p(translate='') upgrade.steps.landing.mode.nondisruptive.description1
     p(translate='') upgrade.steps.landing.mode.nondisruptive.description2

--- a/assets/app/features/upgrade/upgrade.constants.js
+++ b/assets/app/features/upgrade/upgrade.constants.js
@@ -23,7 +23,7 @@
         .constant('STOP_OPENSTACK_SERVICES_TIMEOUT_INTERVAL', 5000)
         .constant('OPENSTACK_BACKUP_TIMEOUT_INTERVAL', 1000)
         .constant('UPGRADE_MODES', {
-            nondisruptive: 'non-disruptive',
+            nondisruptive: 'non_disruptive',
             normal: 'normal',
             none: 'none',
         });

--- a/routes/api/upgrade.js
+++ b/routes/api/upgrade.js
@@ -18,6 +18,10 @@ var status_counter = -1,
         },
         remaining_nodes: 95,
         upgraded_nodes: 60,
+        crowbar_backup: '/var/lib/crowbar/backup/upgrade-backup.....tar.gz',
+        openstack_backup: '/var/lib/crowbar/backup/6-yp-7-openstack_dump.sql.gz',
+        suggested_upgrade_mode: 'non_disruptive',
+        selected_upgrade_mode: 'normal',
         steps: {
             prechecks: {
                 status: 'pending',
@@ -72,6 +76,7 @@ router.get('/', function(req, res) {
 
     function testedStatus() {
         switch (status_counter) {
+        default:
         case 0:
             return 'pending';
         case 1:
@@ -82,7 +87,6 @@ router.get('/', function(req, res) {
         case 4:
             return 'running';
         case 5:
-        default:
             return 'passed';
         }
     }


### PR DESCRIPTION
Mode value was changed to symbol in the backend and could not contain
dash ('-') anymore.
In addition some missing pieces were added to the mocked backend.