### PR TITLE
upgrade: Handle multi-node upgrade status

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-nodes.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-nodes.controller.js
@@ -32,7 +32,9 @@
 
         vm.nodesUpgrade = {
             beginUpgradeNodes: beginUpgradeNodes,
-            currentNode: undefined,
+            currentNodes: [],
+            currentAction: null,
+            maxDisplayNodes: 4,
             upgradedNodes: 0,
             totalNodes: 0,
             completed: false,
@@ -103,7 +105,8 @@
 
             vm.nodesUpgrade.upgradedNodes = response.data.upgraded_nodes;
             vm.nodesUpgrade.totalNodes = response.data.upgraded_nodes + response.data.remaining_nodes;
-            vm.nodesUpgrade.currentNode = response.data.current_node;
+            vm.nodesUpgrade.currentNodes = response.data.current_nodes;
+            vm.nodesUpgrade.currentAction = response.data.current_node_action;
         }
 
         function upgradeError(errorResponse) {

--- a/assets/app/features/upgrade/controllers/upgrade-nodes.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-nodes.controller.spec.js
@@ -14,7 +14,8 @@ describe('Upgrade Nodes Controller', function() {
         initialStatusResponseData = {
             current_step: 'nodes',
             substep: null,
-            current_node: null,
+            current_nodes: null,
+            current_node_action: null,
             remaining_nodes: null,
             upgraded_nodes: null,
             steps: {
@@ -80,13 +81,14 @@ describe('Upgrade Nodes Controller', function() {
             initialStatusResponseData,
             {
                 current_step: 'finished',
-                current_node: {
+                current_nodes: [{
                     alias: 'compute-1234',
                     name: 'compute.1234.suse.com',
                     ip: '123.2.3.4',
                     role: 'compute',
                     state: 'finished'
-                },
+                }],
+                current_node_action: 'finished upgrading',
                 remaining_nodes: 0,
                 upgraded_nodes: totalNodes,
                 steps: {
@@ -104,13 +106,14 @@ describe('Upgrade Nodes Controller', function() {
             {},
             initialStatusResponseData,
             {
-                current_node: {
+                current_nodes: [{
                     alias: 'compute-345',
                     name: 'compute.345.suse.com',
                     ip: '34.2.3.4',
                     role: 'compute',
                     state: 'migrating VMs'
-                },
+                }],
+                current_node_action: 'doing something',
                 remaining_nodes: totalNodes - upgradedNodes,
                 upgraded_nodes:  upgradedNodes,
                 steps: {
@@ -272,19 +275,14 @@ describe('Upgrade Nodes Controller', function() {
                     upgradeStatusFactory.waitForStepToEnd.calls.argsFor(0)[2](runningUpgradeResponse);
                 });
 
-                it('should update the current node\'s alias', function () {
-                    expect(controller.nodesUpgrade.currentNode.alias)
-                        .toEqual(runningUpgradeData.current_node.alias);
+                it('should update the current nodes list', function () {
+                    expect(controller.nodesUpgrade.currentNodes)
+                        .toEqual(runningUpgradeData.current_nodes);
                 });
 
-                it('should update the current node\'s role', function () {
-                    expect(controller.nodesUpgrade.currentNode.role)
-                        .toEqual(runningUpgradeData.current_node.role);
-                });
-
-                it('should update the current node\'s state', function () {
-                    expect(controller.nodesUpgrade.currentNode.state)
-                        .toEqual(runningUpgradeData.current_node.state);
+                it('should update current action', function () {
+                    expect(controller.nodesUpgrade.currentAction)
+                        .toEqual(runningUpgradeData.current_node_action);
                 });
 
                 it('should update upgraded nodes count', function () {
@@ -331,19 +329,14 @@ describe('Upgrade Nodes Controller', function() {
                     upgradeStatusFactory.waitForStepToEnd.calls.argsFor(0)[4](runningUpgradeResponse);
                 });
 
-                it('should update the current node\'s alias', function () {
-                    expect(controller.nodesUpgrade.currentNode.alias)
-                        .toEqual(runningUpgradeData.current_node.alias);
+                it('should update the current nodes list', function () {
+                    expect(controller.nodesUpgrade.currentNodes)
+                        .toEqual(runningUpgradeData.current_nodes);
                 });
 
-                it('should update the current node\'s role', function () {
-                    expect(controller.nodesUpgrade.currentNode.role)
-                        .toEqual(runningUpgradeData.current_node.role);
-                });
-
-                it('should update the current node\'s state', function () {
-                    expect(controller.nodesUpgrade.currentNode.state)
-                        .toEqual(runningUpgradeData.current_node.state);
+                it('should update current action', function () {
+                    expect(controller.nodesUpgrade.currentAction)
+                        .toEqual(runningUpgradeData.current_node_action);
                 });
 
                 it('should update upgraded nodes count', function () {
@@ -466,19 +459,14 @@ describe('Upgrade Nodes Controller', function() {
                         assert.isTrue(controller.nodesUpgrade.completed);
                     });
 
-                    it('should update the current node\'s alias', function () {
-                        expect(controller.nodesUpgrade.currentNode.alias)
-                            .toEqual(completedUpgradeData.current_node.alias);
+                    it('should update the current nodes list', function () {
+                        expect(controller.nodesUpgrade.currentNodes)
+                            .toEqual(completedUpgradeData.current_nodes);
                     });
 
-                    it('should update the current node\'s role', function () {
-                        expect(controller.nodesUpgrade.currentNode.role)
-                            .toEqual(completedUpgradeData.current_node.role);
-                    });
-
-                    it('should update the current node\'s state', function () {
-                        expect(controller.nodesUpgrade.currentNode.state)
-                            .toEqual(completedUpgradeData.current_node.state);
+                    it('should update current action', function () {
+                        expect(controller.nodesUpgrade.currentAction)
+                            .toEqual(completedUpgradeData.current_node_action);
                     });
 
                     it('should update upgraded nodes count', function () {
@@ -527,19 +515,14 @@ describe('Upgrade Nodes Controller', function() {
                         assert.isFalse(controller.nodesUpgrade.completed);
                     });
 
-                    it('should update the current node\'s alias', function () {
-                        expect(controller.nodesUpgrade.currentNode.alias)
-                            .toEqual(runningUpgradeData.current_node.alias);
+                    it('should update the current nodes list', function () {
+                        expect(controller.nodesUpgrade.currentNodes)
+                            .toEqual(runningUpgradeData.current_nodes);
                     });
 
-                    it('should update the current node\'s role', function () {
-                        expect(controller.nodesUpgrade.currentNode.role)
-                            .toEqual(runningUpgradeData.current_node.role);
-                    });
-
-                    it('should update the current node\'s state', function () {
-                        expect(controller.nodesUpgrade.currentNode.state)
-                            .toEqual(runningUpgradeData.current_node.state);
+                    it('should update current action', function () {
+                        expect(controller.nodesUpgrade.currentAction)
+                            .toEqual(runningUpgradeData.current_node_action);
                     });
 
                     it('should update upgraded nodes count', function () {

--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -122,7 +122,7 @@
                 "status": {
                     "progress-bar": "{{current}} of {{total}} Nodes Upgraded",
                     "current-nodes": "Current Nodes:",
-                    "multi-nodes-line": "{{name}} / role: {{ role }}",
+                    "multi-nodes-line": "{{name}}",
                     "more-line": "... and {{moreCount}} more",
                     "current-action": "Current Action: {{action}}",
                     "current-node": "Current Node: {{name}}",

--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -121,9 +121,13 @@
                 },
                 "status": {
                     "progress-bar": "{{current}} of {{total}} Nodes Upgraded",
-                    "current-node": "Current Node: {{nodeName}}",
-                    "node-role": "Node Role: {{nodeRole}}",
-                    "node-status": "Status: {{status}}"
+                    "current-nodes": "Current Nodes:",
+                    "multi-nodes-line": "{{name}} / role: {{ role }}",
+                    "more-line": "... and {{moreCount}} more",
+                    "current-action": "Current Action: {{action}}",
+                    "current-node": "Current Node: {{name}}",
+                    "node-role": "Node Role: {{role}}",
+                    "node-status": "Status: {{state}}"
                 }
             }
         },

--- a/assets/app/features/upgrade/templates/upgrade-nodes-page.jade
+++ b/assets/app/features/upgrade/templates/upgrade-nodes-page.jade
@@ -17,45 +17,36 @@
         .progress-label.text-center(translate='upgrade.steps.upgrade-nodes.status.progress-bar',
             translate-values='{current: upgradeNodesVm.nodesUpgrade.upgradedNodes, total: upgradeNodesVm.nodesUpgrade.totalNodes}'
         )
-    .row(ng-if="upgradeNodesVm.nodesUpgrade.currentAction")
-        .col-md-8.col-md-offset-4
-            .upgrade-progress(
-                translate='upgrade.steps.upgrade-nodes.status.current-action',
-                translate-values='{"action": upgradeNodesVm.nodesUpgrade.currentAction}'
-            )
-    .row(ng-if="upgradeNodesVm.nodesUpgrade.currentNodes.length === 1")
-        .col-md-8.col-md-offset-4
-            .upgrade-progress(
-                title='{{upgradeNodesVm.nodesUpgrade.currentNodes[0].ip}}',
-                translate='upgrade.steps.upgrade-nodes.status.current-node',
-                translate-values='upgradeNodesVm.nodesUpgrade.currentNodes[0]'
-            )
-        .col-md-8.col-md-offset-4
-            .upgrade-progress(
-                translate='upgrade.steps.upgrade-nodes.status.node-role',
-                translate-values='upgradeNodesVm.nodesUpgrade.currentNodes[0]'
-            )
-        .col-md-8.col-md-offset-4
-            .upgrade-progress(
-                translate='upgrade.steps.upgrade-nodes.status.node-status',
-                translate-values='upgradeNodesVm.nodesUpgrade.currentNodes[0]'
-            )
-    .row(ng-if="upgradeNodesVm.nodesUpgrade.currentNodes.length > 1")
+    .row.upgrade-progress(ng-if="upgradeNodesVm.nodesUpgrade.currentNodes.length === 1")
+        .col-md-8.col-md-offset-4(
+            title='{{upgradeNodesVm.nodesUpgrade.currentNodes[0].ip}}',
+            translate='upgrade.steps.upgrade-nodes.status.current-node',
+            translate-values='upgradeNodesVm.nodesUpgrade.currentNodes[0]'
+        )
+    .row.upgrade-progress(ng-if="upgradeNodesVm.nodesUpgrade.currentNodes.length > 1")
         .col-md-8.col-md-offset-4(translate='') upgrade.steps.upgrade-nodes.status.current-nodes
-    .row(ng-if="upgradeNodesVm.nodesUpgrade.currentNodes.length > 1",
+        .col-md-8.col-md-offset-4(ng-if="upgradeNodesVm.nodesUpgrade.currentNodes.length > 1",
         ng-repeat="currentNode in upgradeNodesVm.nodesUpgrade.currentNodes | limitTo:upgradeNodesVm.nodesUpgrade.maxDisplayNodes")
-        .col-md-8.col-md-offset-4
             .multi-node-line(
                 title='{{currentNode.ip}}',
                 translate='upgrade.steps.upgrade-nodes.status.multi-nodes-line',
                 translate-values='currentNode'
             )
-    .row(ng-if="upgradeNodesVm.nodesUpgrade.currentNodes.length > upgradeNodesVm.nodesUpgrade.maxDisplayNodes")
-        .col-md-8.col-md-offset-4
+        .col-md-8.col-md-offset-4(ng-if="upgradeNodesVm.nodesUpgrade.currentNodes.length > upgradeNodesVm.nodesUpgrade.maxDisplayNodes")
             .multi-node-line(
                 translate='upgrade.steps.upgrade-nodes.status.more-line',
                 translate-values='{"totalCount": upgradeNodesVm.nodesUpgrade.currentNodes.length,\
                     "moreCount": upgradeNodesVm.nodesUpgrade.currentNodes.length - upgradeNodesVm.nodesUpgrade.maxDisplayNodes\
                 }'
             )
+    .row.upgrade-progress(ng-if="upgradeNodesVm.nodesUpgrade.currentNodes.length > 0")
+        .col-md-8.col-md-offset-4(
+            translate='upgrade.steps.upgrade-nodes.status.node-role',
+            translate-values='upgradeNodesVm.nodesUpgrade.currentNodes[0]'
+        )
+    .row.upgrade-progress(ng-if="upgradeNodesVm.nodesUpgrade.currentAction")
+        .col-md-8.col-md-offset-4(
+            translate='upgrade.steps.upgrade-nodes.status.current-action',
+            translate-values='{"action": upgradeNodesVm.nodesUpgrade.currentAction}'
+        )
 suse-modal(error="upgradeNodesVm.nodesUpgrade.errors", translation-prefix="upgrade.errors")

--- a/assets/app/features/upgrade/templates/upgrade-nodes-page.jade
+++ b/assets/app/features/upgrade/templates/upgrade-nodes-page.jade
@@ -17,21 +17,45 @@
         .progress-label.text-center(translate='upgrade.steps.upgrade-nodes.status.progress-bar',
             translate-values='{current: upgradeNodesVm.nodesUpgrade.upgradedNodes, total: upgradeNodesVm.nodesUpgrade.totalNodes}'
         )
-    .row(ng-if="upgradeNodesVm.nodesUpgrade.currentNode")
+    .row(ng-if="upgradeNodesVm.nodesUpgrade.currentAction")
         .col-md-8.col-md-offset-4
             .upgrade-progress(
-                title='{{upgradeNodesVm.nodesUpgrade.currentNode.ip}}',
+                translate='upgrade.steps.upgrade-nodes.status.current-action',
+                translate-values='{"action": upgradeNodesVm.nodesUpgrade.currentAction}'
+            )
+    .row(ng-if="upgradeNodesVm.nodesUpgrade.currentNodes.length === 1")
+        .col-md-8.col-md-offset-4
+            .upgrade-progress(
+                title='{{upgradeNodesVm.nodesUpgrade.currentNodes[0].ip}}',
                 translate='upgrade.steps.upgrade-nodes.status.current-node',
-                translate-values='{"nodeIP": upgradeNodesVm.nodesUpgrade.currentNode.ip, "nodeName": upgradeNodesVm.nodesUpgrade.currentNode.name}'
+                translate-values='upgradeNodesVm.nodesUpgrade.currentNodes[0]'
             )
         .col-md-8.col-md-offset-4
             .upgrade-progress(
                 translate='upgrade.steps.upgrade-nodes.status.node-role',
-                translate-values='{"nodeRole": upgradeNodesVm.nodesUpgrade.currentNode.role}'
+                translate-values='upgradeNodesVm.nodesUpgrade.currentNodes[0]'
             )
         .col-md-8.col-md-offset-4
             .upgrade-progress(
                 translate='upgrade.steps.upgrade-nodes.status.node-status',
-                translate-values='{status: upgradeNodesVm.nodesUpgrade.currentNode.state}'
+                translate-values='upgradeNodesVm.nodesUpgrade.currentNodes[0]'
+            )
+    .row(ng-if="upgradeNodesVm.nodesUpgrade.currentNodes.length > 1")
+        .col-md-8.col-md-offset-4(translate='') upgrade.steps.upgrade-nodes.status.current-nodes
+    .row(ng-if="upgradeNodesVm.nodesUpgrade.currentNodes.length > 1",
+        ng-repeat="currentNode in upgradeNodesVm.nodesUpgrade.currentNodes | limitTo:upgradeNodesVm.nodesUpgrade.maxDisplayNodes")
+        .col-md-8.col-md-offset-4
+            .multi-node-line(
+                title='{{currentNode.ip}}',
+                translate='upgrade.steps.upgrade-nodes.status.multi-nodes-line',
+                translate-values='currentNode'
+            )
+    .row(ng-if="upgradeNodesVm.nodesUpgrade.currentNodes.length > upgradeNodesVm.nodesUpgrade.maxDisplayNodes")
+        .col-md-8.col-md-offset-4
+            .multi-node-line(
+                translate='upgrade.steps.upgrade-nodes.status.more-line',
+                translate-values='{"totalCount": upgradeNodesVm.nodesUpgrade.currentNodes.length,\
+                    "moreCount": upgradeNodesVm.nodesUpgrade.currentNodes.length - upgradeNodesVm.nodesUpgrade.maxDisplayNodes\
+                }'
             )
 suse-modal(error="upgradeNodesVm.nodesUpgrade.errors", translation-prefix="upgrade.errors")

--- a/assets/app/features/upgrade/templates/upgrade-nodes-page.less
+++ b/assets/app/features/upgrade/templates/upgrade-nodes-page.less
@@ -22,4 +22,8 @@
     .upgrade-progress {
         margin: 0px 0px 15px;
     }
+
+    .multi-node-line {
+        margin-left: 24px;
+    }
 }

--- a/routes/api/upgrade.js
+++ b/routes/api/upgrade.js
@@ -5,17 +5,56 @@ var errors = ['001', '002', '003'];
 
 var status_counter = -1,
     tested_step = 'nodes',
+    current_count = 6,
     simulate_temporary_downtime = true,
     status = {
         current_step: 'prechecks',
         substep: null,
-        current_node:  {
-            alias: 'controller-1',
-            name: 'controller.1234.suse.com',
-            ip: '1.2.3.4',
-            role: 'controller',
-            state: 'post-upgrade'
-        },
+        current_nodes:  [
+            {
+                alias: 'controller-1',
+                name: 'controller.1234.suse.com',
+                ip: '192.168.123.4',
+                role: 'controller',
+                state: 'upgrading'
+            },
+            {
+                alias: 'controller-2',
+                name: 'controller.1235.suse.com',
+                ip: '192.168.123.5',
+                role: 'controller',
+                state: 'upgrading'
+            },
+            {
+                alias: 'controller-3',
+                name: 'controller.1236.suse.com',
+                ip: '192.168.123.6',
+                role: 'controller',
+                state: 'upgrading'
+            },
+            {
+                alias: 'controller-4',
+                name: 'controller.1237.suse.com',
+                ip: '192.168.123.7',
+                role: 'controller',
+                state: 'upgrading'
+            },
+            {
+                alias: 'controller-5',
+                name: 'controller.1238.suse.com',
+                ip: '192.168.123.8',
+                role: 'controller',
+                state: 'upgrading'
+            },
+            {
+                alias: 'controller-6',
+                name: 'controller.1239.suse.com',
+                ip: '192.168.123.9',
+                role: 'controller',
+                state: 'upgrading'
+            }
+        ].slice(0, current_count),
+        current_node_action: 'live-evacuting nova instances',
         remaining_nodes: 95,
         upgraded_nodes: 60,
         crowbar_backup: '/var/lib/crowbar/backup/upgrade-backup.....tar.gz',


### PR DESCRIPTION
During disruptive upgrade multiple nodes can be upgraded in prallel.
The status structure was adapted to this on the backend side.
This change updates the UI to match the backend.

**EDIT**
Final screenshots attached below in a separate comment.

1 node:
![zrzut ekranu z 2017-03-09 11-53-47](https://cloud.githubusercontent.com/assets/2458112/23747571/7776c24c-04c0-11e7-8de4-ca6bd8fd926b.png)
2-4 nodes:
![zrzut ekranu z 2017-03-09 11-53-22](https://cloud.githubusercontent.com/assets/2458112/23747569/7772ef96-04c0-11e7-86dd-54faefb45487.png)
&gt;4 nodes:
![zrzut ekranu z 2017-03-09 11-52-34](https://cloud.githubusercontent.com/assets/2458112/23747568/774fd056-04c0-11e7-91ca-e5894767ed6b.png)
