### PR TITLE
upgrade: Display final text instead of last status

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-nodes.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-nodes.controller.js
@@ -49,7 +49,7 @@
                 UPGRADE_STEPS.nodes,
                 vm.nodesUpgrade,
                 waitForUpgradeNodesToEnd,
-                upgradeStepsFactory.setCurrentStepCompleted,
+                upgradeSuccess,
                 upgradeError,
                 updateModel
             );
@@ -69,14 +69,7 @@
             upgradeStatusFactory.waitForStepToEnd(
                 UPGRADE_STEPS.nodes,
                 NODES_UPGRADE_TIMEOUT_INTERVAL,
-                function (response) {
-                    vm.nodesUpgrade.running = false;
-                    vm.nodesUpgrade.completed = true;
-
-                    upgradeStepsFactory.setCurrentStepCompleted();
-
-                    updateModel(response);
-                },
+                upgradeSuccess,
                 upgradeError,
                 updateModel
             );
@@ -107,6 +100,15 @@
             vm.nodesUpgrade.totalNodes = response.data.upgraded_nodes + response.data.remaining_nodes;
             vm.nodesUpgrade.currentNodes = response.data.current_nodes;
             vm.nodesUpgrade.currentAction = response.data.current_node_action;
+        }
+
+        function upgradeSuccess(response) {
+            updateModel(response);
+
+            vm.nodesUpgrade.running = false;
+            vm.nodesUpgrade.completed = true;
+
+            upgradeStepsFactory.setCurrentStepCompleted();
         }
 
         function upgradeError(errorResponse) {

--- a/assets/app/features/upgrade/controllers/upgrade-nodes.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-nodes.controller.spec.js
@@ -168,7 +168,6 @@ describe('Upgrade Nodes Controller', function() {
         beforeEach(function () {
             spyOn(upgradeStatusFactory, 'syncStatusFlags').and.callFake(
                 function(step, flagsObject, onRunning, onSuccess, onError, postSync) {
-                    onSuccess(initialStatusResponse);
                     postSync(initialStatusResponse);
                 }
             );
@@ -397,7 +396,6 @@ describe('Upgrade Nodes Controller', function() {
 
             spyOn(upgradeStatusFactory, 'syncStatusFlags').and.callFake(
                 function(step, flagsObject, onRunning, onSuccess, onError, postSync) {
-                    onSuccess(initialStatusResponse);
                     postSync(initialStatusResponse);
                 }
             );

--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -119,6 +119,7 @@
                 "form": {
                     "upgrade-nodes": "Upgrade Nodes"
                 },
+                "finished": "Upgrade is completed. Click Finish button to go back to the dashboard.",
                 "status": {
                     "progress-bar": "{{current}} of {{total}} Nodes Upgraded",
                     "current-nodes": "Current Nodes:",

--- a/assets/app/features/upgrade/templates/upgrade-nodes-page.jade
+++ b/assets/app/features/upgrade/templates/upgrade-nodes-page.jade
@@ -17,6 +17,7 @@
         .progress-label.text-center(translate='upgrade.steps.upgrade-nodes.status.progress-bar',
             translate-values='{current: upgradeNodesVm.nodesUpgrade.upgradedNodes, total: upgradeNodesVm.nodesUpgrade.totalNodes}'
         )
+
     .row.upgrade-progress(ng-if="upgradeNodesVm.nodesUpgrade.currentNodes.length === 1")
         .col-md-8.col-md-offset-4(
             title='{{upgradeNodesVm.nodesUpgrade.currentNodes[0].ip}}',
@@ -44,9 +45,12 @@
             translate='upgrade.steps.upgrade-nodes.status.node-role',
             translate-values='upgradeNodesVm.nodesUpgrade.currentNodes[0]'
         )
-    .row.upgrade-progress(ng-if="upgradeNodesVm.nodesUpgrade.currentAction")
+    .row.upgrade-progress(ng-if="upgradeNodesVm.nodesUpgrade.currentAction && upgradeNodesVm.nodesUpgrade.currentNodes.length > 0")
         .col-md-8.col-md-offset-4(
             translate='upgrade.steps.upgrade-nodes.status.current-action',
             translate-values='{"action": upgradeNodesVm.nodesUpgrade.currentAction}'
         )
+
+    .step-hint(ng-if="upgradeNodesVm.nodesUpgrade.completed", translate='') upgrade.steps.upgrade-nodes.finished
+
 suse-modal(error="upgradeNodesVm.nodesUpgrade.errors", translation-prefix="upgrade.errors")

--- a/assets/app/features/upgrade/upgrade.less
+++ b/assets/app/features/upgrade/upgrade.less
@@ -94,6 +94,7 @@
 
                 .step-hint {
                     color: @success-text;
+                    text-align: center;
 
                     &:before {
                         color: @success-icon;


### PR DESCRIPTION
When upgrade is finished, backend doesn't report any current_nodes
anymore. New message was added to highlight the completed upgrade.

Backend change: https://github.com/crowbar/crowbar-core/pull/1142

![zrzut ekranu z 2017-03-10 14-32-39](https://cloud.githubusercontent.com/assets/2458112/23797165/c4ef4b50-059e-11e7-977e-6cd42643da1e.png)
