### PR TITLE
upgrade: Add confirmation for cancel upgrade

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
@@ -45,18 +45,23 @@
             // https://trello.com/c/5fXGm1a7/45-2-27-restore-last-step
             upgradeStatusFactory.syncStatusFlags(
                 UPGRADE_STEPS.admin, vm.adminUpgrade,
-                waitForUpgradeToEnd, upgradeStepsFactory.setCurrentStepCompleted
+                waitForUpgradeToEnd, upgradeStepsFactory.setCurrentStepCompleted, null,
+                function (/*response*/) {
+                    if (vm.adminUpgrade.completed || vm.adminUpgrade.running) {
+                        upgradeStepsFactory.setCancelAllowed(false);
+                    }
+                }
             );
         }
 
         function beginAdminUpgrade() {
             vm.adminUpgrade.running = true;
+            upgradeStepsFactory.setCancelAllowed(false);
 
             crowbarFactory.upgrade()
                 .then(
                     // In case of success
                     function (/*response*/) {
-                        vm.adminUpgrade.running = true;
                         waitForUpgradeToEnd();
                     },
                     // In case of failure

--- a/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.spec.js
@@ -36,7 +36,8 @@ describe('Upgrade Flow - Upgrade Administration Server Controller', function () 
         it('should call syncStatusFlags() to update the state', function () {
             expect(upgradeStatusFactory.syncStatusFlags).toHaveBeenCalledWith(
                 'admin', controller.adminUpgrade,
-                jasmine.any(Function), upgradeStepsFactory.setCurrentStepCompleted
+                jasmine.any(Function), upgradeStepsFactory.setCurrentStepCompleted, null,
+                jasmine.any(Function)
             );
         });
     });

--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -5,6 +5,16 @@
             "next": "Next",
             "last": "Finish"
         },
+        "cancel": {
+            "title": "Cancel Upgrade",
+            "buttons": {
+                "yes": "Yes",
+                "no": "No"
+            },
+            "description": "If upgrade is canceled, nodes will return to \"ready\" state and you will be redirected to the dashboard. If any changes were already made to the cloud (e.g. new repositories were configured), they will not be reverted automatically. You will need to manually revert those changes to fully return the cloud to the previous state.",
+            "question": "Are you sure you want to cancel the upgrade process?",
+            "ongoing": "Please wait..."
+        },
         "steps": {
             "landing": {
                 "form": {

--- a/assets/app/features/upgrade/steps.factory.js
+++ b/assets/app/features/upgrade/steps.factory.js
@@ -18,7 +18,10 @@
             activeStep: {},
             refeshStepsList: refeshStepsList,
             setCurrentStepCompleted: setCurrentStepCompleted,
-            isCurrentStepCompleted: isCurrentStepCompleted
+            isCurrentStepCompleted: isCurrentStepCompleted,
+            isCancelAllowed: isCancelAllowed,
+            setCancelAllowed: setCancelAllowed,
+            reset: reset,
         };
 
         return factory;
@@ -28,6 +31,17 @@
         }
         function setCurrentStepCompleted() {
             factory.activeStep.finished = true;
+        }
+
+        function isCancelAllowed() {
+            return factory.activeStep.cancelAllowed;
+        }
+        function setCancelAllowed(value) {
+            factory.activeStep.cancelAllowed = value;
+        }
+
+        function reset() {
+            factory.steps = initialSteps();
         }
 
         function refeshStepsList() {
@@ -55,6 +69,7 @@
                     title: 'upgrade.steps-key.codes.backup',
                     state: 'upgrade.backup',
                     active: false,
+                    cancelAllowed: true,
                     finished: false
                 },
                 {
@@ -62,6 +77,7 @@
                     title: 'upgrade.steps-key.codes.administration-repositories-checks',
                     state: 'upgrade.administration-repository-checks',
                     active: false,
+                    cancelAllowed: true,
                     finished: false
                 },
                 {
@@ -69,6 +85,7 @@
                     title: 'upgrade.steps-key.codes.upgrade-administration-server',
                     state: 'upgrade.upgrade-administration-server',
                     active: false,
+                    cancelAllowed: true,
                     finished: false
                 },
                 {

--- a/assets/app/features/upgrade/steps.factory.spec.js
+++ b/assets/app/features/upgrade/steps.factory.spec.js
@@ -6,6 +6,7 @@ describe('Steps Factory', function () {
             title: 'upgrade.steps-key.codes.backup',
             state: 'upgrade.backup',
             active: false,
+            cancelAllowed: true,
             finished: false
         },
         {
@@ -13,6 +14,7 @@ describe('Steps Factory', function () {
             title: 'upgrade.steps-key.codes.administration-repositories-checks',
             state: 'upgrade.administration-repository-checks',
             active: false,
+            cancelAllowed: true,
             finished: false
         },
         {
@@ -20,6 +22,7 @@ describe('Steps Factory', function () {
             title: 'upgrade.steps-key.codes.upgrade-administration-server',
             state: 'upgrade.upgrade-administration-server',
             active: false,
+            cancelAllowed: true,
             finished: false
         },
         {

--- a/assets/app/features/upgrade/templates/cancel-dialog.jade
+++ b/assets/app/features/upgrade/templates/cancel-dialog.jade
@@ -1,0 +1,16 @@
+.modal-content.cancel-dialog
+    .modal-header
+        button.close(type='button', ng-click='cancelVm.dismiss()', aria-label='Close', ng-disabled='cancelVm.running')
+            span(aria-hidden='true') ×
+        h4.modal-title(translate='') upgrade.cancel.title
+    .modal-body
+        p(translate='') upgrade.cancel.description
+        p(translate='') upgrade.cancel.question
+    .modal-footer
+        .pull-left.ongoing
+            suse-lazy-spinner(delay='100', active='cancelVm.running', visible='cancelVm.spinnerVisible')
+            span(translate='', ng-if='cancelVm.spinnerVisible') upgrade.cancel.ongoing
+        button.btn.btn-primary(type='button', ng-click='cancelVm.cancelUpgrade()', ng-disabled='cancelVm.running')
+            span(translate='') upgrade.cancel.buttons.yes
+        button.btn.btn-default(type='button', ng-click='cancelVm.dismiss()', ng-disabled='cancelVm.running')
+            span(translate='') upgrade.cancel.buttons.no

--- a/assets/app/features/upgrade/templates/cancel-dialog.less
+++ b/assets/app/features/upgrade/templates/cancel-dialog.less
@@ -1,0 +1,11 @@
+/* Start= features/upgrade/templates/cancel-dialog.less */
+.cancel-dialog {
+    .ongoing span {
+        margin-left: 6px;
+    }
+
+    p {
+        text-align: justify;
+    }
+}
+/* End= features/upgrade/templates/cancel-dialog.less */

--- a/assets/app/features/upgrade/templates/upgrade.jade
+++ b/assets/app/features/upgrade/templates/upgrade.jade
@@ -6,4 +6,4 @@
       .col-lg-9.upgrade-details-container
         div.upgrade-details(ui-view='')
   .panel-footer
-    crowbar-upgrade-nav.clearfix(steps='upgradeVm.steps', on-cancel='upgradeVm.cancelUpgrade()')
+    crowbar-upgrade-nav.clearfix(steps='upgradeVm.steps', on-cancel='upgradeVm.confirmCancel()')

--- a/assets/app/features/upgrade/upgrade.controller.js
+++ b/assets/app/features/upgrade/upgrade.controller.js
@@ -9,20 +9,21 @@
      * This is the controller that will be used across the upgrade process.
      */
     angular.module('crowbarApp.upgrade')
-        .controller('UpgradeController', UpgradeController);
+        .controller('UpgradeController', UpgradeController)
+        .controller('CancelController', CancelController);
 
     UpgradeController.$inject = [
-        '$scope', '$translate', '$state', 'upgradeStepsFactory',
-        'upgradeFactory', 'UPGRADE_LAST_STATE_KEY'
+        '$scope',
+        '$translate',
+        '$uibModal',
+        'upgradeStepsFactory',
     ];
     // @ngInject
     function UpgradeController(
         $scope,
         $translate,
-        $state,
-        upgradeStepsFactory,
-        upgradeFactory,
-        UPGRADE_LAST_STATE_KEY
+        $uibModal,
+        upgradeStepsFactory
     ) {
         var vm = this;
         vm.steps = {
@@ -30,9 +31,10 @@
             nextStep: upgradeStepsFactory.showNextStep,
             isCurrentStepCompleted: upgradeStepsFactory.isCurrentStepCompleted,
             isLastStep: upgradeStepsFactory.isLastStep,
+            isCancelAllowed: upgradeStepsFactory.isCancelAllowed,
         };
 
-        vm.cancelUpgrade = cancelUpgrade;
+        vm.confirmCancel = confirmCancel;
 
         // Get Steps list from provider
         vm.steps.list = upgradeStepsFactory.steps;
@@ -41,16 +43,68 @@
         // Watch for view changes on the Step in order to update the steps list.
         $scope.$on('$viewContentLoaded', upgradeStepsFactory.refeshStepsList);
 
+        function confirmCancel() {
+            $uibModal.open({
+                templateUrl: 'app/features/upgrade/templates/cancel-dialog.html',
+                controller: 'CancelController',
+                controllerAs: 'cancelVm',
+            });
+        }
+
+    }
+
+    CancelController.$inject = [
+        '$uibModalInstance',
+        '$scope',
+        '$window',
+        'upgradeFactory',
+        'upgradeStepsFactory',
+        'UPGRADE_LAST_STATE_KEY',
+    ];
+    // @ngInject
+    function CancelController(
+        $uibModalInstance,
+        $scope,
+        $window,
+        upgradeFactory,
+        upgradeStepsFactory,
+        UPGRADE_LAST_STATE_KEY
+    ) {
+        var vm = this;
+        vm.cancelUpgrade = cancelUpgrade;
+        vm.dismiss = $uibModalInstance.dismiss;
+        vm.running = false;
+
+        activate();
+
+        function activate() {
+            // block closing of modal if the process is still running
+            $scope.$on('modal.closing', function(event/*, reason, closed*/) {
+                if (vm.running) {
+                    event.preventDefault();
+                }
+            });
+        }
         /**
          * Trigger cancellation of the upgrade process and go back to landing page
          */
         function cancelUpgrade() {
-            upgradeFactory.cancelUpgrade().then(function(/* response */) {
-                // clear last page seen by the user
-                localStorage.removeItem(UPGRADE_LAST_STATE_KEY);
-                // TODO(skazi): in final solution this should redirect to crowbar dashboard
-                $state.go('upgrade-landing');
-            });
+            vm.running = true;
+            upgradeFactory.cancelUpgrade().then(
+                function(/* response */) {
+                    vm.running = false;
+                    $uibModalInstance.dismiss();
+                    // reset steps state
+                    upgradeStepsFactory.reset();
+                    // clear last page seen by the user
+                    localStorage.removeItem(UPGRADE_LAST_STATE_KEY);
+                    // go to dashboard
+                    $window.location.href = '/';
+                },
+                function(/* errorResponse */) {
+                    vm.running = false;
+                }
+            );
         }
     }
 })();

--- a/assets/app/widgets/crowbar-upgrade-nav/crowbar-upgrade-nav.directive.jade
+++ b/assets/app/widgets/crowbar-upgrade-nav/crowbar-upgrade-nav.directive.jade
@@ -1,4 +1,4 @@
-button.btn.btn-default.pull-left(type='button', ng-click="onCancel()")
+button.btn.btn-default.pull-left(type='button', ng-click="onCancel()", ng-disabled="!steps.isCancelAllowed()")
   span(aria-hidden="true", translate='') upgrade.nav.cancel
 button.btn.btn-primary.pull-right(type='button', ng-click="steps.nextStep()", ng-if="!steps.isLastStep()", ng-disabled="!steps.isCurrentStepCompleted()" )
   span(aria-hidden="true", translate='') upgrade.nav.next


### PR DESCRIPTION
The cancelation of upgrade is possible only before admin server upgrade
was started. Additional confirmation dialog is displayed before the
action is triggered. It is kept on the screen until the action is completed.

confirmation dialog:
![zrzut ekranu z 2017-03-16 14-59-25](https://cloud.githubusercontent.com/assets/2458112/23999668/5a20cffa-0a59-11e7-80c5-bf6afaf87c78.png)
cancel ongoing:
![zrzut ekranu z 2017-03-16 14-59-42](https://cloud.githubusercontent.com/assets/2458112/23999669/5a439efe-0a59-11e7-9449-5332731965ea.png)
