### PR TITLE
upgrade: Display old errors when opening DB page

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-database-configuration.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-database-configuration.controller.js
@@ -50,7 +50,7 @@
         // functions
         function activate() {
             upgradeStatusFactory.syncStatusFlags(UPGRADE_STEPS.database, vm,
-                undefined, upgradeStepsFactory.setCurrentStepCompleted);
+                undefined, upgradeStepsFactory.setCurrentStepCompleted, serverError);
         }
 
         function createServer() {
@@ -62,14 +62,7 @@
                         vm.completed = true;
                         upgradeStepsFactory.setCurrentStepCompleted();
                     },
-                    // error
-                    function (errorResponse) {
-                        if (angular.isDefined(errorResponse.data.errors)) {
-                            vm.errors = errorResponse.data;
-                        } else {
-                            vm.errors = UNEXPECTED_ERROR_DATA;
-                        }
-                    }
+                    serverError
                 )
                 .finally(function () {
                     vm.running = false;
@@ -85,18 +78,21 @@
                         vm.completed = true;
                         upgradeStepsFactory.setCurrentStepCompleted();
                     },
-                    // error
-                    function (errorResponse) {
-                        if (angular.isDefined(errorResponse.data.errors)) {
-                            vm.errors = errorResponse.data;
-                        } else {
-                            vm.errors = UNEXPECTED_ERROR_DATA;
-                        }
-                    }
+                    serverError
                 )
                 .finally(function () {
                     vm.running = false;
                 });
+        }
+
+        function serverError(errorResponse) {
+            if (angular.isDefined(errorResponse.data.errors)) {
+                vm.errors = errorResponse.data;
+            } else if (angular.isDefined(errorResponse.data.steps)) {
+                vm.errors = { errors: errorResponse.data.steps.database.errors };
+            } else {
+                vm.errors = UNEXPECTED_ERROR_DATA;
+            }
         }
     }
 })();

--- a/assets/app/features/upgrade/controllers/upgrade-database-configuration.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-database-configuration.controller.spec.js
@@ -72,7 +72,7 @@ describe('Upgrade Flow - Create Connect Database Controller', function () {
         expect(upgradeStatusFactory.syncStatusFlags).toHaveBeenCalledTimes(1);
         expect(upgradeStatusFactory.syncStatusFlags).toHaveBeenCalledWith(
             UPGRADE_STEPS.database, controller,
-            undefined, upgradeStepsFactory.setCurrentStepCompleted
+            undefined, upgradeStepsFactory.setCurrentStepCompleted, jasmine.any(Function)
         );
     });
 


### PR DESCRIPTION
Errors from previous step runs are stored in status file. When re-opening
DB configuration page after failed run the errors from status file will now
be displayed to the user.