### PR TITLE
upgrade: add missing precheck error label

### DIFF
--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -191,6 +191,7 @@
             "maintenance_updates_installed": "Maintenance Updates",
             "clusters_health_crm_failures": "Some crm commands failed",
             "clusters_health_failed_actions": "Some Clusters Health actions have failed",
+            "unsupported_cluster_setup": "Unsupported Cluster Configuration",
             "admin_upgrade": "Administration Server upgrade failed",
             "database_connect": "Connecting to Database failed",
             "database_new": "Creating Database failed",


### PR DESCRIPTION
Unsupported Cluster Configuration precheck was added and requires
new label for the error code.

Backend PR: https://github.com/crowbar/crowbar-core/pull/1185