### PR TITLE
upgrade: Label for non-KVM compute error

### DIFF
--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -178,6 +178,7 @@
             "nodes_not_ready": "Nodes not ready",
             "no_live_migration": "Live migration not configured",
             "no_resources": "Not enough free compute resources",
+            "non_kvm_computes": "Non-KVM compute nodes found",
             "zypper_errors": "Zypper error",
             "failed_proposals": "Failed proposals",
             "too_many_replicas": "Too many Swift replicas",


### PR DESCRIPTION
Defined in https://github.com/crowbar/crowbar-core/pull/1189