### PR TITLE
upgrade: Update admin and nodes repo names

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.js
@@ -34,13 +34,13 @@
                     status: false,
                     label: 'upgrade.repositories.codes.SLES12-SP3-Updates'
                 },
-                'SUSE-OpenStack-Cloud-8-Pool': {
+                'SUSE-OpenStack-Cloud-Crowbar-8-Pool': {
                     status: false,
-                    label: 'upgrade.repositories.codes.SUSE-OpenStack-Cloud-8-Pool'
+                    label: 'upgrade.repositories.codes.SUSE-OpenStack-Cloud-Crowbar-8-Pool'
                 },
-                'SUSE-OpenStack-Cloud-8-Updates': {
+                'SUSE-OpenStack-Cloud-Crowbar-8-Updates': {
                     status: false,
-                    label: 'upgrade.repositories.codes.SUSE-OpenStack-Cloud-8-Updates'
+                    label: 'upgrade.repositories.codes.SUSE-OpenStack-Cloud-Crowbar-8-Updates'
                 }
             },
             runRepoChecks: runRepoChecks

--- a/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.js
@@ -26,21 +26,21 @@
             completed: false,
             valid: false,
             checks: {
-                'SLES12-SP2-Pool': {
+                'SLES12-SP3-Pool': {
                     status: false,
-                    label: 'upgrade.repositories.codes.SLES12-SP2-Pool'
+                    label: 'upgrade.repositories.codes.SLES12-SP3-Pool'
                 },
-                'SLES12-SP2-Updates': {
+                'SLES12-SP3-Updates': {
                     status: false,
-                    label: 'upgrade.repositories.codes.SLES12-SP2-Updates'
+                    label: 'upgrade.repositories.codes.SLES12-SP3-Updates'
                 },
-                'SUSE-OpenStack-Cloud-7-Pool': {
+                'SUSE-OpenStack-Cloud-8-Pool': {
                     status: false,
-                    label: 'upgrade.repositories.codes.SUSE-OpenStack-Cloud-7-Pool'
+                    label: 'upgrade.repositories.codes.SUSE-OpenStack-Cloud-8-Pool'
                 },
-                'SUSE-OpenStack-Cloud-7-Updates': {
+                'SUSE-OpenStack-Cloud-8-Updates': {
                     status: false,
-                    label: 'upgrade.repositories.codes.SUSE-OpenStack-Cloud-7-Updates'
+                    label: 'upgrade.repositories.codes.SUSE-OpenStack-Cloud-8-Updates'
                 }
             },
             runRepoChecks: runRepoChecks

--- a/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.spec.js
@@ -4,31 +4,31 @@ describe('Upgrade Flow - Admin Repositories Checks Controller', function () {
         passingRepoChecks = {
             os: {
                 available: true,
-                repos: ['SLES12-SP2-Pool', 'SLES12-SP2-Updates'],
+                repos: ['SLES12-SP3-Pool', 'SLES12-SP3-Updates'],
             },
             openstack: {
                 available: true,
-                repos: ['SUSE-OpenStack-Cloud-7-Pool', 'SUSE-OpenStack-Cloud-7-Updates'],
+                repos: ['SUSE-OpenStack-Cloud-8-Pool', 'SUSE-OpenStack-Cloud-8-Updates'],
             }
         },
         failingRepoChecks = {
             os: {
                 available: false,
-                repos: ['SLES12-SP2-Pool', 'SLES12-SP2-Updates'],
+                repos: ['SLES12-SP3-Pool', 'SLES12-SP3-Updates'],
             },
             openstack: {
                 available: false,
-                repos: ['SUSE-OpenStack-Cloud-7-Pool', 'SUSE-OpenStack-Cloud-7-Updates'],
+                repos: ['SUSE-OpenStack-Cloud-8-Pool', 'SUSE-OpenStack-Cloud-8-Updates'],
             }
         },
         partiallyFailingRepoChecks = {
             os: {
                 available: true,
-                repos: ['SLES12-SP2-Pool', 'SLES12-SP2-Updates'],
+                repos: ['SLES12-SP3-Pool', 'SLES12-SP3-Updates'],
             },
             openstack: {
                 available: false,
-                repos: ['SUSE-OpenStack-Cloud-7-Pool', 'SUSE-OpenStack-Cloud-7-Updates'],
+                repos: ['SUSE-OpenStack-Cloud-8-Pool', 'SUSE-OpenStack-Cloud-8-Updates'],
             }
         },
         failingErrors = {

--- a/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-administration-repositories-checks.controller.spec.js
@@ -8,7 +8,7 @@ describe('Upgrade Flow - Admin Repositories Checks Controller', function () {
             },
             openstack: {
                 available: true,
-                repos: ['SUSE-OpenStack-Cloud-8-Pool', 'SUSE-OpenStack-Cloud-8-Updates'],
+                repos: ['SUSE-OpenStack-Cloud-Crowbar-8-Pool', 'SUSE-OpenStack-Cloud-Crowbar-8-Updates'],
             }
         },
         failingRepoChecks = {
@@ -18,7 +18,7 @@ describe('Upgrade Flow - Admin Repositories Checks Controller', function () {
             },
             openstack: {
                 available: false,
-                repos: ['SUSE-OpenStack-Cloud-8-Pool', 'SUSE-OpenStack-Cloud-8-Updates'],
+                repos: ['SUSE-OpenStack-Cloud-Crowbar-8-Pool', 'SUSE-OpenStack-Cloud-Crowbar-8-Updates'],
             }
         },
         partiallyFailingRepoChecks = {
@@ -28,7 +28,7 @@ describe('Upgrade Flow - Admin Repositories Checks Controller', function () {
             },
             openstack: {
                 available: false,
-                repos: ['SUSE-OpenStack-Cloud-8-Pool', 'SUSE-OpenStack-Cloud-8-Updates'],
+                repos: ['SUSE-OpenStack-Cloud-Crowbar-8-Pool', 'SUSE-OpenStack-Cloud-Crowbar-8-Updates'],
             }
         },
         failingErrors = {

--- a/assets/app/features/upgrade/controllers/upgrade-nodes-repositories-checks.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-nodes-repositories-checks.controller.js
@@ -61,13 +61,13 @@
                     status: false,
                     label: 'upgrade.repositories.codes.SLES12-SP3-Updates'
                 },
-                'SUSE-OpenStack-Cloud-8-Pool': {
+                'SUSE-OpenStack-Cloud-Crowbar-8-Pool': {
                     status: false,
-                    label: 'upgrade.repositories.codes.SUSE-OpenStack-Cloud-8-Pool'
+                    label: 'upgrade.repositories.codes.SUSE-OpenStack-Cloud-Crowbar-8-Pool'
                 },
-                'SUSE-OpenStack-Cloud-8-Updates': {
+                'SUSE-OpenStack-Cloud-Crowbar-8-Updates': {
                     status: false,
-                    label: 'upgrade.repositories.codes.SUSE-OpenStack-Cloud-8-Updates'
+                    label: 'upgrade.repositories.codes.SUSE-OpenStack-Cloud-Crowbar-8-Updates'
                 }
             },
             runRepoChecks: runRepoChecks,

--- a/assets/app/features/upgrade/controllers/upgrade-nodes-repositories-checks.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-nodes-repositories-checks.controller.js
@@ -29,23 +29,23 @@
         var vm = this,
             addonsRepos = {
                 'ha': {
-                    'SLE12-SP2-HA-Pool': {
+                    'SLE12-SP3-HA-Pool': {
                         status: false,
-                        label: 'upgrade.repositories.codes.SLE12-SP2-HA-Pool'
+                        label: 'upgrade.repositories.codes.SLE12-SP3-HA-Pool'
                     },
-                    'SLE12-SP2-HA-Updates': {
+                    'SLE12-SP3-HA-Updates': {
                         status: false,
-                        label: 'upgrade.repositories.codes.SLE12-SP2-HA-Updates'
+                        label: 'upgrade.repositories.codes.SLE12-SP3-HA-Updates'
                     },
                 },
                 'ceph': {
-                    'SUSE-Enterprise-Storage-4-Pool': {
+                    'SUSE-Enterprise-Storage-5-Pool': {
                         status: false,
-                        label: 'upgrade.repositories.codes.SUSE-Enterprise-Storage-4-Pool'
+                        label: 'upgrade.repositories.codes.SUSE-Enterprise-Storage-5-Pool'
                     },
-                    'SUSE-Enterprise-Storage-4-Updates': {
+                    'SUSE-Enterprise-Storage-5-Updates': {
                         status: false,
-                        label: 'upgrade.repositories.codes.SUSE-Enterprise-Storage-4-Updates'
+                        label: 'upgrade.repositories.codes.SUSE-Enterprise-Storage-5-Updates'
                     },
                 },
             };
@@ -53,21 +53,21 @@
             completed: false,
             valid: false,
             checks: {
-                'SLES12-SP2-Pool': {
+                'SLES12-SP3-Pool': {
                     status: false,
-                    label: 'upgrade.repositories.codes.SLES12-SP2-Pool'
+                    label: 'upgrade.repositories.codes.SLES12-SP3-Pool'
                 },
-                'SLES12-SP2-Updates': {
+                'SLES12-SP3-Updates': {
                     status: false,
-                    label: 'upgrade.repositories.codes.SLES12-SP2-Updates'
+                    label: 'upgrade.repositories.codes.SLES12-SP3-Updates'
                 },
-                'SUSE-OpenStack-Cloud-7-Pool': {
+                'SUSE-OpenStack-Cloud-8-Pool': {
                     status: false,
-                    label: 'upgrade.repositories.codes.SUSE-OpenStack-Cloud-7-Pool'
+                    label: 'upgrade.repositories.codes.SUSE-OpenStack-Cloud-8-Pool'
                 },
-                'SUSE-OpenStack-Cloud-7-Updates': {
+                'SUSE-OpenStack-Cloud-8-Updates': {
                     status: false,
-                    label: 'upgrade.repositories.codes.SUSE-OpenStack-Cloud-7-Updates'
+                    label: 'upgrade.repositories.codes.SUSE-OpenStack-Cloud-8-Updates'
                 }
             },
             runRepoChecks: runRepoChecks,

--- a/assets/app/features/upgrade/controllers/upgrade-nodes-repositories-checks.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-nodes-repositories-checks.controller.spec.js
@@ -5,20 +5,20 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             'ceph': {
                 'available': false,
                 'repos': [
-                    'SUSE-Enterprise-Storage-4-Pool',
-                    'SUSE-Enterprise-Storage-4-Updates'
+                    'SUSE-Enterprise-Storage-5-Pool',
+                    'SUSE-Enterprise-Storage-5-Updates'
                 ],
                 'errors': {
                     'missing': {
                         'x86_64': [
-                            'SUSE-Enterprise-Storage-4-Pool',
-                            'SUSE-Enterprise-Storage-4-Updates'
+                            'SUSE-Enterprise-Storage-5-Pool',
+                            'SUSE-Enterprise-Storage-5-Updates'
                         ]
                     },
                     'inactive': {
                         'x86_64': [
-                            'SUSE-Enterprise-Storage-4-Pool',
-                            'SUSE-Enterprise-Storage-4-Updates'
+                            'SUSE-Enterprise-Storage-5-Pool',
+                            'SUSE-Enterprise-Storage-5-Updates'
                         ]
                     }
                 }
@@ -26,20 +26,20 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             'ha': {
                 'available': false,
                 'repos': [
-                    'SLE12-SP2-HA-Pool',
-                    'SLE12-SP2-HA-Updates'
+                    'SLE12-SP3-HA-Pool',
+                    'SLE12-SP3-HA-Updates'
                 ],
                 'errors': {
                     'missing': {
                         'x86_64': [
-                            'SLE12-SP2-HA-Pool',
-                            'SLE12-SP2-HA-Updates'
+                            'SLE12-SP3-HA-Pool',
+                            'SLE12-SP3-HA-Updates'
                         ]
                     },
                     'inactive': {
                         'x86_64': [
-                            'SLE12-SP2-HA-Pool',
-                            'SLE12-SP2-HA-Updates'
+                            'SLE12-SP3-HA-Pool',
+                            'SLE12-SP3-HA-Updates'
                         ]
                     }
                 }
@@ -47,20 +47,20 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             'os': {
                 'available': false,
                 'repos': [
-                    'SLES12-SP2-Pool',
-                    'SLES12-SP2-Updates'
+                    'SLES12-SP3-Pool',
+                    'SLES12-SP3-Updates'
                 ],
                 'errors': {
                     'missing': {
                         'x86_64': [
-                            'SLES12-SP2-Pool',
-                            'SLES12-SP2-Updates'
+                            'SLES12-SP3-Pool',
+                            'SLES12-SP3-Updates'
                         ]
                     },
                     'inactive': {
                         'x86_64': [
-                            'SLES12-SP2-Pool',
-                            'SLES12-SP2-Updates'
+                            'SLES12-SP3-Pool',
+                            'SLES12-SP3-Updates'
                         ]
                     }
                 }
@@ -68,20 +68,20 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             'openstack': {
                 'available': false,
                 'repos': [
-                    'SUSE-OpenStack-Cloud-7-Pool',
-                    'SUSE-OpenStack-Cloud-7-Updates'
+                    'SUSE-OpenStack-Cloud-8-Pool',
+                    'SUSE-OpenStack-Cloud-8-Updates'
                 ],
                 'errors': {
                     'missing': {
                         'x86_64': [
-                            'SUSE-OpenStack-Cloud-7-Pool',
-                            'SUSE-OpenStack-Cloud-7-Updates'
+                            'SUSE-OpenStack-Cloud-8-Pool',
+                            'SUSE-OpenStack-Cloud-8-Updates'
                         ]
                     },
                     'inactive': {
                         'x86_64': [
-                            'SUSE-OpenStack-Cloud-7-Pool',
-                            'SUSE-OpenStack-Cloud-7-Updates'
+                            'SUSE-OpenStack-Cloud-8-Pool',
+                            'SUSE-OpenStack-Cloud-8-Updates'
                         ]
                     }
                 }
@@ -91,32 +91,32 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             'ceph': {
                 'available': true,
                 'repos': [
-                    'SUSE-Enterprise-Storage-4-Pool',
-                    'SUSE-Enterprise-Storage-4-Updates'
+                    'SUSE-Enterprise-Storage-5-Pool',
+                    'SUSE-Enterprise-Storage-5-Updates'
                 ],
                 'errors': {}
             },
             'ha': {
                 'available': true,
                 'repos': [
-                    'SLE12-SP2-HA-Pool',
-                    'SLE12-SP2-HA-Updates'
+                    'SLE12-SP3-HA-Pool',
+                    'SLE12-SP3-HA-Updates'
                 ],
                 'errors': {}
             },
             'os': {
                 'available': true,
                 'repos': [
-                    'SLES12-SP2-Pool',
-                    'SLES12-SP2-Updates'
+                    'SLES12-SP3-Pool',
+                    'SLES12-SP3-Updates'
                 ],
                 'errors': {}
             },
             'openstack': {
                 'available': true,
                 'repos': [
-                    'SUSE-OpenStack-Cloud-7-Pool',
-                    'SUSE-OpenStack-Cloud-7-Updates'
+                    'SUSE-OpenStack-Cloud-8-Pool',
+                    'SUSE-OpenStack-Cloud-8-Updates'
                 ],
                 'errors': {}
             }
@@ -125,18 +125,18 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             'ceph': {
                 'available': false,
                 'repos': [
-                    'SUSE-Enterprise-Storage-4-Pool',
-                    'SUSE-Enterprise-Storage-4-Updates'
+                    'SUSE-Enterprise-Storage-5-Pool',
+                    'SUSE-Enterprise-Storage-5-Updates'
                 ],
                 'errors': {
                     'missing': {
                         'x86_64': [
-                            'SUSE-Enterprise-Storage-4-Updates'
+                            'SUSE-Enterprise-Storage-5-Updates'
                         ]
                     },
                     'inactive': {
                         'x86_64': [
-                            'SUSE-Enterprise-Storage-4-Updates'
+                            'SUSE-Enterprise-Storage-5-Updates'
                         ]
                     }
                 }
@@ -144,20 +144,20 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             'ha': {
                 'available': false,
                 'repos': [
-                    'SLE12-SP2-HA-Pool',
-                    'SLE12-SP2-HA-Updates'
+                    'SLE12-SP3-HA-Pool',
+                    'SLE12-SP3-HA-Updates'
                 ],
                 'errors': {
                     'missing': {
                         'x86_64': [
-                            'SLE12-SP2-HA-Pool',
-                            'SLE12-SP2-HA-Updates'
+                            'SLE12-SP3-HA-Pool',
+                            'SLE12-SP3-HA-Updates'
                         ]
                     },
                     'inactive': {
                         'x86_64': [
-                            'SLE12-SP2-HA-Pool',
-                            'SLE12-SP2-HA-Updates'
+                            'SLE12-SP3-HA-Pool',
+                            'SLE12-SP3-HA-Updates'
                         ]
                     }
                 }
@@ -165,18 +165,18 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             'os': {
                 'available': false,
                 'repos': [
-                    'SLES12-SP2-Pool',
-                    'SLES12-SP2-Updates'
+                    'SLES12-SP3-Pool',
+                    'SLES12-SP3-Updates'
                 ],
                 'errors': {
                     'missing': {
                         'x86_64': [
-                            'SLES12-SP2-Pool'
+                            'SLES12-SP3-Pool'
                         ]
                     },
                     'inactive': {
                         'x86_64': [
-                            'SLES12-SP2-Pool'
+                            'SLES12-SP3-Pool'
                         ]
                     }
                 }
@@ -184,8 +184,8 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             'openstack': {
                 'available': true,
                 'repos': [
-                    'SUSE-OpenStack-Cloud-7-Pool',
-                    'SUSE-OpenStack-Cloud-7-Updates'
+                    'SUSE-OpenStack-Cloud-8-Pool',
+                    'SUSE-OpenStack-Cloud-8-Updates'
                 ],
                 'errors': {}
             }
@@ -358,37 +358,37 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
 
                 var langKeyPrefix = 'upgrade.repositories.codes.',
                     expectedChecks = {
-                        'SLES12-SP2-Pool': {
+                        'SLES12-SP3-Pool': {
                             status: false,
-                            label: langKeyPrefix + 'SLES12-SP2-Pool'
+                            label: langKeyPrefix + 'SLES12-SP3-Pool'
                         },
-                        'SLES12-SP2-Updates': {
+                        'SLES12-SP3-Updates': {
                             status: true,
-                            label: langKeyPrefix + 'SLES12-SP2-Updates'
+                            label: langKeyPrefix + 'SLES12-SP3-Updates'
                         },
-                        'SUSE-OpenStack-Cloud-7-Pool': {
+                        'SUSE-OpenStack-Cloud-8-Pool': {
                             status: true,
-                            label: langKeyPrefix + 'SUSE-OpenStack-Cloud-7-Pool'
+                            label: langKeyPrefix + 'SUSE-OpenStack-Cloud-8-Pool'
                         },
-                        'SUSE-OpenStack-Cloud-7-Updates': {
+                        'SUSE-OpenStack-Cloud-8-Updates': {
                             status: true,
-                            label: langKeyPrefix + 'SUSE-OpenStack-Cloud-7-Updates'
+                            label: langKeyPrefix + 'SUSE-OpenStack-Cloud-8-Updates'
                         },
-                        'SLE12-SP2-HA-Pool': {
+                        'SLE12-SP3-HA-Pool': {
                             status: false,
-                            label: langKeyPrefix + 'SLE12-SP2-HA-Pool'
+                            label: langKeyPrefix + 'SLE12-SP3-HA-Pool'
                         },
-                        'SLE12-SP2-HA-Updates': {
+                        'SLE12-SP3-HA-Updates': {
                             status: false,
-                            label: langKeyPrefix + 'SLE12-SP2-HA-Updates'
+                            label: langKeyPrefix + 'SLE12-SP3-HA-Updates'
                         },
-                        'SUSE-Enterprise-Storage-4-Pool': {
+                        'SUSE-Enterprise-Storage-5-Pool': {
                             status: true,
-                            label: langKeyPrefix + 'SUSE-Enterprise-Storage-4-Pool'
+                            label: langKeyPrefix + 'SUSE-Enterprise-Storage-5-Pool'
                         },
-                        'SUSE-Enterprise-Storage-4-Updates': {
+                        'SUSE-Enterprise-Storage-5-Updates': {
                             status: false,
-                            label: langKeyPrefix + 'SUSE-Enterprise-Storage-4-Updates'
+                            label: langKeyPrefix + 'SUSE-Enterprise-Storage-5-Updates'
                         }
                     };
                 expect(controller.repoChecks.checks).toEqual(expectedChecks);

--- a/assets/app/features/upgrade/controllers/upgrade-nodes-repositories-checks.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-nodes-repositories-checks.controller.spec.js
@@ -68,20 +68,20 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             'openstack': {
                 'available': false,
                 'repos': [
-                    'SUSE-OpenStack-Cloud-8-Pool',
-                    'SUSE-OpenStack-Cloud-8-Updates'
+                    'SUSE-OpenStack-Cloud-Crowbar-8-Pool',
+                    'SUSE-OpenStack-Cloud-Crowbar-8-Updates'
                 ],
                 'errors': {
                     'missing': {
                         'x86_64': [
-                            'SUSE-OpenStack-Cloud-8-Pool',
-                            'SUSE-OpenStack-Cloud-8-Updates'
+                            'SUSE-OpenStack-Cloud-Crowbar-8-Pool',
+                            'SUSE-OpenStack-Cloud-Crowbar-8-Updates'
                         ]
                     },
                     'inactive': {
                         'x86_64': [
-                            'SUSE-OpenStack-Cloud-8-Pool',
-                            'SUSE-OpenStack-Cloud-8-Updates'
+                            'SUSE-OpenStack-Cloud-Crowbar-8-Pool',
+                            'SUSE-OpenStack-Cloud-Crowbar-8-Updates'
                         ]
                     }
                 }
@@ -115,8 +115,8 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             'openstack': {
                 'available': true,
                 'repos': [
-                    'SUSE-OpenStack-Cloud-8-Pool',
-                    'SUSE-OpenStack-Cloud-8-Updates'
+                    'SUSE-OpenStack-Cloud-Crowbar-8-Pool',
+                    'SUSE-OpenStack-Cloud-Crowbar-8-Updates'
                 ],
                 'errors': {}
             }
@@ -184,8 +184,8 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
             'openstack': {
                 'available': true,
                 'repos': [
-                    'SUSE-OpenStack-Cloud-8-Pool',
-                    'SUSE-OpenStack-Cloud-8-Updates'
+                    'SUSE-OpenStack-Cloud-Crowbar-8-Pool',
+                    'SUSE-OpenStack-Cloud-Crowbar-8-Updates'
                 ],
                 'errors': {}
             }
@@ -366,13 +366,13 @@ describe('Upgrade Flow - Nodes Repositories Checks Controller', function () {
                             status: true,
                             label: langKeyPrefix + 'SLES12-SP3-Updates'
                         },
-                        'SUSE-OpenStack-Cloud-8-Pool': {
+                        'SUSE-OpenStack-Cloud-Crowbar-8-Pool': {
                             status: true,
-                            label: langKeyPrefix + 'SUSE-OpenStack-Cloud-8-Pool'
+                            label: langKeyPrefix + 'SUSE-OpenStack-Cloud-Crowbar-8-Pool'
                         },
-                        'SUSE-OpenStack-Cloud-8-Updates': {
+                        'SUSE-OpenStack-Cloud-Crowbar-8-Updates': {
                             status: true,
-                            label: langKeyPrefix + 'SUSE-OpenStack-Cloud-8-Updates'
+                            label: langKeyPrefix + 'SUSE-OpenStack-Cloud-Crowbar-8-Updates'
                         },
                         'SLE12-SP3-HA-Pool': {
                             status: false,

--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -149,18 +149,16 @@
                 "SLES12-SP2-Updates": "SUSE Linux Enterprise Server 12 SP2 Updates",
                 "SUSE-OpenStack-Cloud-7-Pool": "SUSE OpenStack Cloud 7",
                 "SUSE-OpenStack-Cloud-7-Updates": "SUSE OpenStack Cloud 7 Updates",
-                "SLES12-SP3-Pool": "SUSE Linux Enterprise Server 12 SP3",
-                "SLES12-SP3-Updates": "SUSE Linux Enterprise Server 12 SP3 Updates",
-                "SUSE-OpenStack-Cloud-8-Pool": "SUSE OpenStack Cloud 8",
-                "SUSE-OpenStack-Cloud-8-Updates": "SUSE OpenStack Cloud 8 Updates",
                 "SLE12-SP2-HA-Pool": "SUSE Linux Enterprise 12 SP2 High Availability",
                 "SLE12-SP2-HA-Updates": "SUSE Linux Enterprise 12 SP2 High Availability Updates",
                 "SUSE-Enterprise-Storage-4-Pool": "SUSE Enterprise Storage 4",
-                "SUSE-Enterprise-Storage-4-Updates": "SUSE Enterprise Storage 4 Updates"
+                "SUSE-Enterprise-Storage-4-Updates": "SUSE Enterprise Storage 4 Updates",
+                "SLES12-SP3-Pool": "SUSE Linux Enterprise Server 12 SP3",
+                "SLES12-SP3-Updates": "SUSE Linux Enterprise Server 12 SP3 Updates",
+                "SUSE-OpenStack-Cloud-Crowbar-8-Pool": "SUSE OpenStack Cloud Crowbar 8",
+                "SUSE-OpenStack-Cloud-Crowbar-8-Updates": "SUSE OpenStack Cloud Crowbar 8 Updates",
                 "SLE12-SP3-HA-Pool": "SUSE Linux Enterprise 12 SP3 High Availability",
-                "SLE12-SP3-HA-Updates": "SUSE Linux Enterprise 12 SP3 High Availability Updates",
-                "SUSE-Enterprise-Storage-5-Pool": "SUSE Enterprise Storage 5",
-                "SUSE-Enterprise-Storage-5-Updates": "SUSE Enterprise Storage 5 Updates"
+                "SLE12-SP3-HA-Updates": "SUSE Linux Enterprise 12 SP3 High Availability Updates"
             }
         },
         "steps-key": {

--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -27,7 +27,7 @@
                         "check-again": "Check"
                     },
                     "codes": {
-                        "updates_installed": "SLES 12 SP1 Maintenance Updates",
+                        "updates_installed": "SLES 12 SP2 Maintenance Updates",
                         "network_sanity": "Network Health",
                         "cloud_health": "Cloud Health",
                         "cloud_deployment": "Deployment Conflicts",
@@ -70,14 +70,14 @@
                 "location": "Backup can be found under \"{{path}}\" on Administration Server."
             },
             "admin-repository-checks": {
-                "title": "Upgrading to SUSE OpenStack Cloud 7 requires updated software repositories for the Administration Server",
+                "title": "Upgrading to SUSE OpenStack Cloud 8 requires updated software repositories for the Administration Server",
                 "description": "Prepare the software repositories locally or via SMT and update the URLs in the Administration Server configuration correspondingly. Refer to \"Software Repository Setup\" chapter of the deployment guide. Click \"Check\" to verify all repositories are available. When all repositories have been verified click on \"Next\" to proceed.",
                 "form": {
                     "check-again": "Check"
                 }
             },
             "upgrade-admin": {
-                "title": "Upgrade the Administration Server to SUSE OpenStack Cloud 7",
+                "title": "Upgrade the Administration Server to SUSE OpenStack Cloud 8",
                 "description": "Please wait until the Administration Server has been upgraded and rebooted.",
                 "notice-title": "IMPORTANT!",
                 "notice-body": "This process might take quite some time. Please do not close the browser window or refresh the page.",
@@ -102,7 +102,7 @@
                 }
             },
             "nodes-repository-checks": {
-                "title": "Upgrading to SUSE OpenStack Cloud 7 requires updated software repositories for all nodes",
+                "title": "Upgrading to SUSE OpenStack Cloud 8 requires updated software repositories for all nodes",
                 "description": "Prepare the software repositories locally or via SMT and update the URLs in the Administration Server configuration correspondingly. Refer to \"Software Repository Setup\" chapter of the deployment guide. Click \"Check\" to verify all repositories are available. When all repositories have been verified click on \"Next\" to proceed.",
                 "form": {
                     "check-again": "Check"
@@ -149,10 +149,18 @@
                 "SLES12-SP2-Updates": "SUSE Linux Enterprise Server 12 SP2 Updates",
                 "SUSE-OpenStack-Cloud-7-Pool": "SUSE OpenStack Cloud 7",
                 "SUSE-OpenStack-Cloud-7-Updates": "SUSE OpenStack Cloud 7 Updates",
+                "SLES12-SP3-Pool": "SUSE Linux Enterprise Server 12 SP3",
+                "SLES12-SP3-Updates": "SUSE Linux Enterprise Server 12 SP3 Updates",
+                "SUSE-OpenStack-Cloud-8-Pool": "SUSE OpenStack Cloud 8",
+                "SUSE-OpenStack-Cloud-8-Updates": "SUSE OpenStack Cloud 8 Updates",
                 "SLE12-SP2-HA-Pool": "SUSE Linux Enterprise 12 SP2 High Availability",
                 "SLE12-SP2-HA-Updates": "SUSE Linux Enterprise 12 SP2 High Availability Updates",
                 "SUSE-Enterprise-Storage-4-Pool": "SUSE Enterprise Storage 4",
                 "SUSE-Enterprise-Storage-4-Updates": "SUSE Enterprise Storage 4 Updates"
+                "SLE12-SP3-HA-Pool": "SUSE Linux Enterprise 12 SP3 High Availability",
+                "SLE12-SP3-HA-Updates": "SUSE Linux Enterprise 12 SP3 High Availability Updates",
+                "SUSE-Enterprise-Storage-5-Pool": "SUSE Enterprise Storage 5",
+                "SUSE-Enterprise-Storage-5-Updates": "SUSE Enterprise Storage 5 Updates"
             }
         },
         "steps-key": {
@@ -189,7 +197,7 @@
             "keystone_hybrid_backend": "Keystone hybrid backend",
             "lbaas_v1": "Old version of LBaaS",
             "repositories_missing": "Required repositories missing",
-            "repositories_too_soon": "SOC7 repositories found",
+            "repositories_too_soon": "SOC8 repositories found",
             "prepare": "Begin Upgrade failed",
             "repocheck_nodes": "Some Checks failed",
             "maintenance_updates_installed": "Maintenance Updates",
@@ -211,7 +219,7 @@
         "text": "SUSE OpenStack Cloud - provided by SUSE"
     },
     "header": {
-        "title": "SUSE OpenStack Cloud: Upgrade 6-7"
+        "title": "SUSE OpenStack Cloud 7 Upgrade Wizard"
     },
     "modal": {
         "close": "Close",


### PR DESCRIPTION
The repo names still point to SOC6. Update them to point to SOC7.