### PR TITLE
upgrade: Refactor postpone nodes upgrade

### DIFF
--- a/assets/app/features/upgrade/steps.factory.js
+++ b/assets/app/features/upgrade/steps.factory.js
@@ -22,10 +22,12 @@
             isCancelAllowed: isCancelAllowed,
             setCancelAllowed: setCancelAllowed,
             reset: reset,
+            upgradeAll: true,
             setUpgradeAll: setUpgradeAll,
             isUpgradeAll: isUpgradeAll,
-            setUpgradeStep: setUpgradeStep,
-            getUpgradeStep: getUpgradeStep,
+            controllersUpgraded: null,
+            setControllersUpgraded: setControllersUpgraded,
+            isControllersUpgraded: isControllersUpgraded,
         };
 
         return factory;
@@ -45,19 +47,19 @@
         }
 
         function isUpgradeAll() {
-            return factory.activeStep.upgradeAll;
+            return factory.upgradeAll;
         }
         function setUpgradeAll(value) {
             // switches between 'Finish' or 'Go to Dashboard'
-            factory.activeStep.upgradeAll = value;
+            factory.upgradeAll = value;
         }
 
-        function getUpgradeStep() {
-            return factory.activeStep.upgradeStep;
+        function isControllersUpgraded() {
+            return factory.controllersUpgraded;
         }
-        function setUpgradeStep(value) {
-            // checks where we are in the upgrade process: 1 is from the beginning, 2 is from resume compute node
-            factory.activeStep.upgradeStep = value;
+        function setControllersUpgraded(value) {
+            // checks where we are in the upgrade process: false is before controllers are upgraded, true is after
+            factory.controllersUpgraded = value;
         }
 
         function reset() {

--- a/assets/app/features/upgrade/templates/upgrade-nodes-page.jade
+++ b/assets/app/features/upgrade/templates/upgrade-nodes-page.jade
@@ -4,7 +4,6 @@
 
     input.upgrade-option(type='checkbox' name='upgrade-compute'
         ng-model='upgradeNodesVm.nodesUpgrade.computeUpgradeEnabled'
-        ng-change='upgradeNodesVm.nodesUpgrade.toggleComputeUpgrade()'
         ng-disabled='upgradeNodesVm.nodesUpgrade.upgradedNodes === upgradeNodesVm.nodesUpgrade.totalNodes || upgradeNodesVm.nodesUpgrade.running')
     span(translate='') upgrade.steps.upgrade-nodes.upgrade-option
 
@@ -12,7 +11,7 @@
         ng-click="upgradeNodesVm.nodesUpgrade.beginUpgradeNodes()",
         ng-disabled="upgradeNodesVm.nodesUpgrade.running || " +
         "(upgradeNodesVm.nodesUpgrade.upgradedNodes === upgradeNodesVm.nodesUpgrade.totalNodes && upgradeNodesVm.nodesUpgrade.completed) || " +
-        "(upgradeNodesVm.nodesUpgrade.getUpgradeStep() === 'compute' && upgradeNodesVm.nodesUpgrade.upgradedNodes < upgradeNodesVm.nodesUpgrade.totalNodes && !upgradeNodesVm.nodesUpgrade.computeUpgradeEnabled)",
+        "(upgradeNodesVm.nodesUpgrade.isControllersUpgraded() && upgradeNodesVm.nodesUpgrade.upgradedNodes < upgradeNodesVm.nodesUpgrade.totalNodes && !upgradeNodesVm.nodesUpgrade.computeUpgradeEnabled)",
         ng-class="{\
             'spinner-visible': upgradeNodesVm.nodesUpgrade.spinnerVisible,\
             active: upgradeNodesVm.nodesUpgrade.running\
@@ -61,6 +60,6 @@
         )
 
     .step-hint(ng-if="upgradeNodesVm.nodesUpgrade.completed && upgradeNodesVm.nodesUpgrade.upgradedNodes === upgradeNodesVm.nodesUpgrade.totalNodes", translate='') upgrade.steps.upgrade-nodes.finished
-    .step-hint(ng-if="!upgradeNodesVm.nodesUpgrade.completed && upgradeNodesVm.nodesUpgrade.getUpgradeStep() === 'compute' && !upgradeNodesVm.nodesUpgrade.running", translate='') upgrade.steps.upgrade-nodes.partially-upgraded
+    .step-hint(ng-if="upgradeNodesVm.nodesUpgrade.showPartialMessage", translate='') upgrade.steps.upgrade-nodes.partially-upgraded
 
 suse-modal(error="upgradeNodesVm.nodesUpgrade.errors", translation-prefix="upgrade.errors")

--- a/assets/app/features/upgrade/templates/upgrade.jade
+++ b/assets/app/features/upgrade/templates/upgrade.jade
@@ -6,4 +6,4 @@
       .col-lg-9.upgrade-details-container
         div.upgrade-details(ui-view='')
   .panel-footer
-    crowbar-upgrade-nav.clearfix(steps='upgradeVm.steps', on-cancel='upgradeVm.confirmCancel()')
+    crowbar-upgrade-nav.clearfix(steps='upgradeVm.steps', on-cancel='upgradeVm.confirmCancel()', on-go-to-dashboard='upgradeVm.postponeUpgradeAndGoToDashboard()')

--- a/assets/app/features/upgrade/upgrade.constants.js
+++ b/assets/app/features/upgrade/upgrade.constants.js
@@ -18,17 +18,13 @@
         .constant('PREPARE_TIMEOUT_INTERVAL', 1000)
         .constant('ADMIN_UPGRADE_ALLOWED_DOWNTIME', 30 * 60 * 1000)
         .constant('ADMIN_UPGRADE_TIMEOUT_INTERVAL', 5000)
-        .constant('NODE_UPGRADE_TIMEOUT_INTERVAL', 30 * 1000)
-        .constant('RESUME_UPGRADE_TIMEOUT_INTERVAL', 5 * 1000)
+        .constant('NODES_UPGRADE_TIMEOUT_INTERVAL', 30 * 1000)
+        .constant('RESUME_UPGRADE_TIMEOUT_DELAY', 5 * 1000)
         .constant('STOP_OPENSTACK_SERVICES_TIMEOUT_INTERVAL', 5000)
         .constant('OPENSTACK_BACKUP_TIMEOUT_INTERVAL', 1000)
         .constant('UPGRADE_MODES', {
             nondisruptive: 'non_disruptive',
             normal: 'normal',
             none: 'none',
-        })
-        .constant('NODE_UPGRADE_STEPS', {
-            controller: 'controller',
-            compute: 'compute',
         });
 })();

--- a/assets/app/features/upgrade/upgrade.controller.js
+++ b/assets/app/features/upgrade/upgrade.controller.js
@@ -15,14 +15,18 @@
     UpgradeController.$inject = [
         '$scope',
         '$translate',
+        '$window',
         '$uibModal',
+        'upgradeFactory',
         'upgradeStepsFactory',
     ];
     // @ngInject
     function UpgradeController(
         $scope,
         $translate,
+        $window,
         $uibModal,
+        upgradeFactory,
         upgradeStepsFactory
     ) {
         var vm = this;
@@ -33,10 +37,11 @@
             isLastStep: upgradeStepsFactory.isLastStep,
             isCancelAllowed: upgradeStepsFactory.isCancelAllowed,
             isUpgradeAll: upgradeStepsFactory.isUpgradeAll,
-            getUpgradeStep: upgradeStepsFactory.getUpgradeStep,
+            isControllersUpgraded: upgradeStepsFactory.isControllersUpgraded,
         };
 
         vm.confirmCancel = confirmCancel;
+        vm.postponeUpgradeAndGoToDashboard = postponeUpgradeAndGoToDashboard;
 
         // Get Steps list from provider
         vm.steps.list = upgradeStepsFactory.steps;
@@ -53,6 +58,11 @@
             });
         }
 
+        function postponeUpgradeAndGoToDashboard() {
+            upgradeFactory.setPostponeComputeNodes().then(
+                function () { $window.location.href = '/'; }
+            );
+        }
     }
 
     CancelController.$inject = [

--- a/assets/app/widgets/crowbar-upgrade-nav/crowbar-upgrade-nav.directive.jade
+++ b/assets/app/widgets/crowbar-upgrade-nav/crowbar-upgrade-nav.directive.jade
@@ -3,10 +3,9 @@ button.btn.btn-default.pull-left(type='button', ng-click="onCancel()", ng-disabl
 button.btn.btn-primary.pull-right(type='button', ng-click="steps.nextStep()", ng-if="!steps.isLastStep()", ng-disabled="!steps.isCurrentStepCompleted()" )
   span(aria-hidden="true", translate='') upgrade.nav.next
 button.btn.btn-primary.pull-right(type='button', ng-click="finish()",
-  ng-if="steps.isLastStep() && steps.isUpgradeAll()",
+  ng-if="steps.isLastStep() && (!steps.isControllersUpgraded() || steps.isUpgradeAll())",
   ng-disabled="!steps.isCurrentStepCompleted() || !steps.isUpgradeAll()")
   span(aria-hidden="true", translate='') upgrade.nav.last
-button.btn.btn-primary.pull-right(type='button', ng-click="goToDashboard()",
-  ng-if="steps.isLastStep() && !steps.isUpgradeAll()",
-  ng-disabled="!steps.isCurrentStepCompleted() && !(!steps.isUpgradeAll() && steps.getUpgradeStep() === 'compute')")
+button.btn.btn-primary.pull-right(type='button', ng-click="onGoToDashboard()",
+  ng-if="steps.isLastStep() && steps.isControllersUpgraded() && !steps.isUpgradeAll()")
   span(aria-hidden="true", translate='') upgrade.nav.dashboard

--- a/assets/app/widgets/crowbar-upgrade-nav/crowbar-upgrade-nav.directive.js
+++ b/assets/app/widgets/crowbar-upgrade-nav/crowbar-upgrade-nav.directive.js
@@ -5,17 +5,13 @@
         .module('crowbarWidgets')
         .directive('crowbarUpgradeNav', [crowbarUpgradeNav]);
 
-    var navController = function ($scope, $window, upgradeFactory) {
+    var navController = function ($scope, $window) {
         $scope.finish = function() {
             $window.location.href = '/';
         }
-        $scope.goToDashboard = function() {
-            upgradeFactory.setPostponeComputeNodes();
-            $window.location.href = '/';
-        };
     };
 
-    navController.$inject = ['$scope', '$window', 'upgradeFactory'];
+    navController.$inject = ['$scope', '$window'];
 
     function crowbarUpgradeNav() {
         return {
@@ -24,6 +20,7 @@
             scope: {
                 steps: '=',
                 onCancel: '&',
+                onGoToDashboard: '&',
             },
             controller: navController,
         };


### PR DESCRIPTION
Code for postponing nodes upgrade was simplified and refactored.
Changes:
- status polling is stopped after controllers if partial upgrade is requested (also removed some obsolete flags)
- synchronization of `computeUpgradeEnabled` and `upgradeStepsFactory` is done using angular `$watch`
- `getUpgradeStep` is changed to `isControllersUpgraded` as it was only used for such checking
- redundant code was removed from around `beginUpgradeNodes`
- `computeUpgradeEnabled` was changed to default to true and get updates from status only when upgrade is running
- `showPartialMessage` flag was added to simplify conditions in template
- removed dependency on `upgradeFactory` from nav widget
- changed postpone to redirect to dashboard after successfull response
- renamed some constants to better match their meaning
- fixed bug: postponed message displayed when computes upgrade gets interrupted by error