### PR TITLE
upgrade: Add wrong_sql_engine error title

### DIFF
--- a/assets/app/features/upgrade/i18n/en.json
+++ b/assets/app/features/upgrade/i18n/en.json
@@ -180,6 +180,7 @@
             "lbaas_v1": "Old version of LBaaS",
             "repositories_missing": "Required repositories missing",
             "repositories_too_soon": "SOC8 repositories found",
+            "wrong_sql_engine": "Wrong SQL engine",
             "prepare": "Begin Upgrade failed",
             "repocheck_nodes": "Some Checks failed",
             "maintenance_updates_installed": "Maintenance Updates",


### PR DESCRIPTION
Added missing title translation for `wrong_sql_engine` precheck error which
was added recently.