### PR TITLE
upgrade: Fix "Next" button behavior

### DIFF
--- a/assets/app/features/upgrade/controllers/upgrade-backup.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-backup.controller.js
@@ -18,8 +18,10 @@ function() {
         'crowbarUtilsFactory',
         '$document',
         'upgradeStepsFactory',
+        'upgradeStatusFactory',
         'upgradeFactory',
         'FileSaver',
+        'UPGRADE_STEPS',
         'UNEXPECTED_ERROR_DATA',
     ];
     // @ngInject
@@ -29,8 +31,10 @@ function() {
         crowbarUtilsFactory,
         $document,
         upgradeStepsFactory,
+        upgradeStatusFactory,
         upgradeFactory,
         FileSaver,
+        UPGRADE_STEPS,
         UNEXPECTED_ERROR_DATA
     ) {
         var vm = this;
@@ -45,6 +49,17 @@ function() {
         activate();
 
         function activate() {
+            upgradeStatusFactory.syncStatusFlags(
+                UPGRADE_STEPS.backup_crowbar,
+                vm.backup,
+                null,
+                function() {
+                    // don't enable "Next" if another step is already active
+                    if (upgradeStepsFactory.activeStep.state === 'upgrade.backup') {
+                        upgradeStepsFactory.setCurrentStepCompleted();
+                    }
+                }
+            );
             updateBackupFilePath();
         }
 

--- a/assets/app/features/upgrade/controllers/upgrade-backup.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-backup.controller.spec.js
@@ -26,6 +26,11 @@ describe('Upgrade Flow - Backup Controller', function() {
         mockedStatusResponse = {
             data: {
                 crowbar_backup: '--some path--',
+                steps: {
+                    backup_crowbar: {
+                        status: 'pending'
+                    },
+                },
             }
         };
 

--- a/assets/app/features/upgrade/controllers/upgrade-openstack-backup.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-openstack-backup.controller.js
@@ -77,7 +77,10 @@
 
             vm.openStackBackup.backupPath = response.data.openstack_backup;
 
-            upgradeStepsFactory.setCurrentStepCompleted()
+            // don't enable "Next" if another step is already active
+            if (upgradeStepsFactory.activeStep.state === 'upgrade.openstack-backup') {
+                upgradeStepsFactory.setCurrentStepCompleted()
+            }
         }
 
         function createBackupError(errorResponse) {

--- a/assets/app/features/upgrade/controllers/upgrade-openstack-services.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-openstack-services.controller.js
@@ -76,7 +76,10 @@
             vm.openStackServices.running = false;
             vm.openStackServices.completed = true;
 
-            upgradeStepsFactory.setCurrentStepCompleted()
+            // don't enable "Next" if another step is already active
+            if (upgradeStepsFactory.activeStep.state === 'upgrade.openstack-services') {
+                upgradeStepsFactory.setCurrentStepCompleted()
+            }
         }
 
         function stopServicesError(errorResponse) {

--- a/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
+++ b/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.js
@@ -44,8 +44,16 @@
             // TODO(itxaka): Not tested yet, tests should be done as part of card:
             // https://trello.com/c/5fXGm1a7/45-2-27-restore-last-step
             upgradeStatusFactory.syncStatusFlags(
-                UPGRADE_STEPS.admin, vm.adminUpgrade,
-                waitForUpgradeToEnd, upgradeStepsFactory.setCurrentStepCompleted, null,
+                UPGRADE_STEPS.admin,
+                vm.adminUpgrade,
+                waitForUpgradeToEnd,
+                function (/*response*/) {
+                    // don't enable "Next" if another step is already active
+                    if (upgradeStepsFactory.activeStep.state === 'upgrade.upgrade-administration-server') {
+                        upgradeStepsFactory.setCurrentStepCompleted();
+                    }
+                },
+                null,
                 function (/*response*/) {
                     if (vm.adminUpgrade.completed || vm.adminUpgrade.running) {
                         upgradeStepsFactory.setCancelAllowed(false);

--- a/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.spec.js
+++ b/assets/app/features/upgrade/controllers/upgrade-upgrade-administration-server.controller.spec.js
@@ -36,7 +36,7 @@ describe('Upgrade Flow - Upgrade Administration Server Controller', function () 
         it('should call syncStatusFlags() to update the state', function () {
             expect(upgradeStatusFactory.syncStatusFlags).toHaveBeenCalledWith(
                 'admin', controller.adminUpgrade,
-                jasmine.any(Function), upgradeStepsFactory.setCurrentStepCompleted, null,
+                jasmine.any(Function), jasmine.any(Function), null,
                 jasmine.any(Function)
             );
         });


### PR DESCRIPTION
When user opened page for already completed step (e.g. via Back button)
for some steps the Next button was incorrectly enabled. This was a race between
code which enforces correct step to be displayed and code in some pages which
enabled Next button if the step was already completed.

In addition this change fixes bsc#1027306 (don't require user to re-run backup
steps).