### PR TITLE
Pin gulp-angular-templatecache version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint-plugin-angular": "^1.3.1",
     "eslint-plugin-chai-expect": "^1.1.1",
     "gulp": "^3.9.1",
-    "gulp-angular-templatecache": "^2.0.0",
+    "gulp-angular-templatecache": "<2.2.7",
     "gulp-bower": "0.0.13",
     "gulp-cache": "^0.4.5",
     "gulp-clean": "^0.3.2",


### PR DESCRIPTION
Some recent changes in gulp-angular-templatecache and/or it's deps
causes failures when building the application. Since we're already
using pretty old versions of modules here, pinning this seems like
a reasonable solution.