### PR TITLE
travis: Stop testing against nodejs4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_install:
     - npm install -g gulp bower
-install: 
+install:
     - npm install
     - bower install
 before_script:
@@ -10,6 +10,4 @@ script:
     - npm test
 language: node_js
 node_js:
-    - "6.3.1"
-    - "4.4.7"
-    - "4.4.5"
+    - "6.17"


### PR DESCRIPTION
All current product releases are using nodejs6.