### PR TITLE
Some debian package manager tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PORT=3000
 WORKDIR /crowbar-ui
 
 RUN apt-get update && \
-    apt-get install -y libfontconfig1 libfontconfig1-dev supervisor
+    apt-get --no-install-recommends install -y libfontconfig1 libfontconfig1-dev supervisor
 RUN npm install --global gulp bower nodemon
 RUN mkdir -p /var/log/supervisor
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .